### PR TITLE
fix(Jenkins): remove caching

### DIFF
--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -43,8 +43,8 @@ pipeline {
   stages {
     stage('Deps') { steps { script {
       /* Avoid checking multiple times. */
-      v1changed = true //versionWasChanged('v1')
-      v2changed = true //versionWasChanged('v2')
+      v1changed = versionWasChanged('v1')
+      v2changed = versionWasChanged('v2')
       /* TODO: Re-add caching of Nim compiler. */
       sh "make V=${params.VERBOSITY} update"
       sh "make V=${params.VERBOSITY} deps"

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -43,8 +43,8 @@ pipeline {
   stages {
     stage('Deps') { steps { script {
       /* Avoid checking multiple times. */
-      v1changed = versionWasChanged('v1')
-      v2changed = versionWasChanged('v2')
+      v1changed = true //versionWasChanged('v1')
+      v2changed = true //versionWasChanged('v2')
       /* TODO: Re-add caching of Nim compiler. */
       sh "make V=${params.VERBOSITY} update"
       sh "make V=${params.VERBOSITY} deps"

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -50,9 +50,9 @@ pipeline {
 //        $class: 'ArbitraryFileCache', excludes: '', includes: '**/*',
 //        path: 'vendor/nimbus-build-system/vendor/Nim/bin',
 //      ]]) 
-//            {
-          sh "make V=${params.VERBOSITY} update"
-//      }
+            {
+        sh "make V=${params.VERBOSITY} update"
+      }
       sh "make V=${params.VERBOSITY} deps"
     } } }
 

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -45,11 +45,11 @@ pipeline {
       /* Avoid checking multiple times. */
       v1changed = versionWasChanged('v1')
       v2changed = versionWasChanged('v2')
-      /* Building Nim compiler takes a while. */
+      /* Building Nim compiler takes a while.
       cache(maxCacheSize: 250, caches: [[
         $class: 'ArbitraryFileCache', excludes: '', includes: '**/*',
         path: 'vendor/nimbus-build-system/vendor/Nim/bin',
-      ]]) {
+      ]]) */ {
         sh "make V=${params.VERBOSITY} update"
       }
       sh "make V=${params.VERBOSITY} deps"

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -45,14 +45,8 @@ pipeline {
       /* Avoid checking multiple times. */
       v1changed = versionWasChanged('v1')
       v2changed = versionWasChanged('v2')
-      /* Building Nim compiler takes a while. */
-//      cache(maxCacheSize: 250, caches: [[
-//        $class: 'ArbitraryFileCache', excludes: '', includes: '**/*',
-//        path: 'vendor/nimbus-build-system/vendor/Nim/bin',
-//      ]]) 
-            {
-        sh "make V=${params.VERBOSITY} update"
-      }
+      /* TODO: Re-add caching of Nim compiler. */
+      sh "make V=${params.VERBOSITY} update"
       sh "make V=${params.VERBOSITY} deps"
     } } }
 

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -2,7 +2,6 @@
 ## See spec for more details:
 ## https://github.com/vacp2p/rfc/tree/master/content/docs/rfcs/35
 ##
-##
 ## Implementation partially inspired by noise-libp2p:
 ## https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/secure/noise.nim
 

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -2,6 +2,7 @@
 ## See spec for more details:
 ## https://github.com/vacp2p/rfc/tree/master/content/docs/rfcs/35
 ##
+##
 ## Implementation partially inspired by noise-libp2p:
 ## https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/secure/noise.nim
 


### PR DESCRIPTION
Since version `2.343`, Jenkins implements a [security fix](https://issues.jenkins.io/browse/JENKINS-67173) which breaks the [Job Cacher](https://plugins.jenkins.io/jobcacher/) plugin used to cache dependencies like the Nim compiler.

In the meantime that the Job Cacher plugins is updated to address this fix, or other alternatives are found, this PR disables implemented Jenkins caching in `nim-waku`.

Related issues are https://github.com/status-im/status-desktop/pull/5560 and https://github.com/status-im/nimbus-eth2/pull/3594