### PR TITLE
chore(migration): avoid unnecessarily calling migration

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -1012,7 +1012,7 @@ when isMainModule:
       else:
         sqliteDatabase = dbRes.value
 
-    if not sqliteDatabase.isNil:
+    if not sqliteDatabase.isNil and (conf.persistPeers or conf.persistMessages):
       # Database initialized. Let's set it up
       sqliteDatabase.runMigrations(conf) # First migrate what we have
 


### PR DESCRIPTION
This PR solves #966.

It minimally updates the current branching, but it gets a bit convoluted.

An alternative would be:

* load peer migration if `--persist-peers` is set
* load messages migration if `--persist-messages` is set
* remove the "if both" branch

(involves altering `runMigrations`, too)

Maybe, it was implemented like this to have to do two separate loads when loading both migration scripts types...
Let me know if you prefer the alternative.
