### PR TITLE
feat(info): add --version cmd flag

### DIFF
--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -27,6 +27,11 @@ type
       desc: "Sets the log level."
       defaultValue: LogLevel.INFO
       name: "log-level" }: LogLevel
+
+    version* {.
+      desc: "prints the version"
+      defaultValue: false
+      name: "version" }: bool
     
     nodekey* {.
       desc: "P2P node private key as 64 char hex string.",

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -1306,6 +1306,12 @@ when isMainModule:
     quit 1 # if we don't leave here, the initialization of conf does not work in the success case
   {.pop.}
 
+  # if called with --version, print the version and quit
+  if conf.version:
+    const git_version {.strdefine.} = "n/a"
+    echo "version / git commit hash: ", git_version
+    quit(QuitSuccess)
+  
   var
     node: WakuNode  # This is the node we're going to setup using the conf
 


### PR DESCRIPTION
Solves #969 in a minimal way.

Prints only the commit hash, if the current version has not been tagged with a version tag.
(That is true for the json RPC call, too.)
If desired, we could add the last version on the current branch as additional info. This would require a new compiler flag in the Makefile.
This PR just prints the info that is available via JSON rpc at the moment.

Example output for untagged version:

```
./build/wakunode2 --version
version / git commit hash: 062668
```