### PR TITLE
feat(store): ability to decouple store from relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ rln
 package-lock.json
 node_modules/
 /.update.timestamp
+
+# Ignore Jetbrains IDE files
+.idea/

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -30,7 +30,7 @@ procSuite "Waku Filter":
     await listenSwitch.start()
 
     var responseRequestIdFuture = newFuture[string]()
-    proc handle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc handle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       check:
         msg.messages.len() == 1
         msg.messages[0] == post
@@ -43,7 +43,7 @@ procSuite "Waku Filter":
     dialSwitch.mount(proto)
     proto.setPeer(listenSwitch.peerInfo.toRemotePeerInfo())
 
-    proc emptyHandle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc emptyHandle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       discard
 
     let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle)
@@ -75,7 +75,7 @@ procSuite "Waku Filter":
     await listenSwitch.start()
 
     var responseCompletionFuture = newFuture[bool]()
-    proc handle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc handle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       check:
         msg.messages.len() == 1
         msg.messages[0] == post
@@ -88,7 +88,7 @@ procSuite "Waku Filter":
     dialSwitch.mount(proto)
     proto.setPeer(listenSwitch.peerInfo.toRemotePeerInfo())
 
-    proc emptyHandle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc emptyHandle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       discard
 
     let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle)
@@ -131,7 +131,7 @@ procSuite "Waku Filter":
     await dialSwitch.start()
 
     var responseRequestIdFuture = newFuture[string]()
-    proc handle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc handle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       discard
 
     let
@@ -161,7 +161,7 @@ procSuite "Waku Filter":
     await listenSwitch.start()
 
     var responseCompletionFuture = newFuture[bool]()
-    proc handle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc handle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       check:
         msg.messages.len() == 1
         msg.messages[0] == post
@@ -174,7 +174,7 @@ procSuite "Waku Filter":
     dialSwitch.mount(proto)
     proto.setPeer(listenSwitch.peerInfo.toRemotePeerInfo())
 
-    proc emptyHandle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc emptyHandle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       discard
 
     let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle, 1.seconds)
@@ -225,7 +225,7 @@ procSuite "Waku Filter":
     await listenSwitch.start()
 
     var responseCompletionFuture = newFuture[bool]()
-    proc handle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc handle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       check:
         msg.messages.len() == 1
         msg.messages[0] == post
@@ -238,7 +238,7 @@ procSuite "Waku Filter":
     dialSwitch.mount(proto)
     proto.setPeer(listenSwitch.peerInfo.toRemotePeerInfo())
 
-    proc emptyHandle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+    proc emptyHandle(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} =
       discard
 
     let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle, 2.seconds)

--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -179,7 +179,7 @@ method init*(wf: WakuFilter) =
     let value = res.value
     if value.push != MessagePush():
       waku_filter_messages.inc(labelValues = ["MessagePush"])
-      wf.pushHandler(value.requestId, value.push)
+      await wf.pushHandler(value.requestId, value.push)
     if value.request != FilterRequest():
       waku_filter_messages.inc(labelValues = ["FilterRequest"])
       if value.request.subscribe:

--- a/waku/v2/protocol/waku_filter/waku_filter_types.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter_types.nim
@@ -15,6 +15,8 @@ const
   MaxRpcSize* = 10 * MaxWakuMessageSize + 64*1024
 
 type
+  PubSubTopic* = string
+
   ContentFilter* = object
     contentTopic*: ContentTopic
 
@@ -22,6 +24,7 @@ type
 
   Filter* = object
     contentFilters*: seq[ContentFilter]
+    pubSubTopic*: PubSubTopic
     handler*: ContentFilterHandler
 
   # @TODO MAYBE MORE INFO?
@@ -29,7 +32,7 @@ type
 
   FilterRequest* = object
     contentFilters*: seq[ContentFilter]
-    pubSubTopic*: string
+    pubSubTopic*: PubSubTopic
     subscribe*: bool
 
   MessagePush* = object
@@ -45,7 +48,7 @@ type
     requestId*: string
     filter*: FilterRequest # @TODO MAKE THIS A SEQUENCE AGAIN?
 
-  MessagePushHandler* = proc(requestId: string, msg: MessagePush) {.gcsafe, closure.}
+  MessagePushHandler* = proc(requestId: string, msg: MessagePush): Future[void] {.gcsafe, closure.}
 
   WakuFilter* = ref object of LPProtocol
     rng*: ref BrHmacDrbgContext


### PR DESCRIPTION
This PR resolves #937 

Now, nodes can combine store protocol either with the relay protocol or with filter protocol. Having the relay mounted is no longer a requirement to support store protocol.