### PR TITLE
chore: disable swap by default

### DIFF
--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -181,7 +181,7 @@ type
 
     swap* {.
       desc: "Enable swap protocol: true|false",
-      defaultValue: true
+      defaultValue: false
       name: "swap" }: bool
     
     ## Lightpush config


### PR DESCRIPTION
Minimal PR to disable `swap` protocol by default.

### Why?

`Swap` is not currently being used or investigated by anyone, yet it is enabled by default in `Soft` mode. Impact of keeping it enabled:
1. Many `INFO` level logs that record accounting state in all nodes.
2. Accounting state with no proper capacity management (i.e. a slow memory leak) being kept for each node involved in a `store` transaction.

We can reenable `swap` once it's used for incentivisation.