### PR TITLE
chore: more regular keepalive pings

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -779,7 +779,7 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
     await sleepAsync(keepalive)
 
 proc startKeepalive*(node: WakuNode) =
-  let defaultKeepalive = 5.minutes # 50% of the default chronosstream timeout duration
+  let defaultKeepalive = 2.minutes # 20% of the default chronosstream timeout duration
 
   info "starting keepalive", keepalive=defaultKeepalive
 


### PR DESCRIPTION
Minimal PR to lower the period between keepalive `PING`s from `5.min` to `2.min`.

### Why?

Libp2p TCP connections have an underlying timeout of `10.min`. The keepalive is meant to prevent these and other timeouts from happening, but once every `5.min` leaves very little room for error (if a node misses one `PING` for some reason it might still trigger a timeout).

Note that we do not necessarily want (or need to) make this period either configurable or dependent on a specific underlying constant (e.g. the TCP timeout), as this is mostly a workaround mechanism for fleet nodes to remain connected during idle periods.