### PR TITLE
chore: reduce unnecessary logging

### DIFF
--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -107,6 +107,11 @@ proc loadFromStorage(pm: PeerManager) =
 ##################   
 
 proc onConnEvent(pm: PeerManager, peerId: PeerID, event: ConnEvent) {.async.} =
+  if not pm.peerStore.addressBook.contains(peerId):
+    ## We only consider connection events if we
+    ## already track some addresses for this peer
+    return
+
   case event.kind
   of ConnEventKind.Connected:
     pm.peerStore.connectionBook[peerId] = Connected

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -500,7 +500,7 @@ when defined(rln):
     ## if contentTopic is empty, then validation takes place for All the messages published on the given pubsubTopic
     ## the message validation logic is according to https://rfc.vac.dev/spec/17/
     proc validator(topic: string, message: messages.Message): Future[pubsub.ValidationResult] {.async.} =
-      debug "rln-relay topic validator is called"
+      trace "rln-relay topic validator is called"
       let msg = WakuMessage.init(message.data) 
       if msg.isOk():
         let 
@@ -509,7 +509,7 @@ when defined(rln):
 
         # check the contentTopic
         if (wakumessage.contentTopic != "") and (contentTopic != "") and (wakumessage.contentTopic != contentTopic):
-          debug "content topic did not match:", contentTopic=wakumessage.contentTopic, payload=payload
+          trace "content topic did not match:", contentTopic=wakumessage.contentTopic, payload=payload
           return pubsub.ValidationResult.Accept
 
         # validate the message
@@ -1044,8 +1044,9 @@ when isMainModule:
 
   # 2/7 Retrieve dynamic bootstrap nodes
   proc retrieveDynamicBootstrapNodes(conf: WakuNodeConf): SetupResult[seq[RemotePeerInfo]] =
-  # DNS discovery
+    
     if conf.dnsDiscovery and conf.dnsDiscoveryUrl != "":
+      # DNS discovery
       debug "Discovering nodes using Waku DNS discovery", url=conf.dnsDiscoveryUrl
 
       var nameServers: seq[TransportAddress]
@@ -1066,6 +1067,8 @@ when isMainModule:
           .mapErr(proc (e: cstring): string = $e)
       else:
         warn "Failed to init Waku DNS discovery"
+    
+    ok(newSeq[RemotePeerInfo]()) # Return an empty seq by default
 
   # 3/7 Initialize node
   proc initNode(conf: WakuNodeConf,

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -619,7 +619,7 @@ proc resume*(ws: WakuStore, peerList: Option[seq[RemotePeerInfo]] = none(seq[Rem
     # if no peerList is set then query from one of the peers stored in the peer manager 
     let peerOpt = ws.peerManager.selectPeer(WakuStoreCodec)
     if peerOpt.isNone():
-      error "no suitable remote peers"
+      warn "no suitable remote peers"
       waku_store_errors.inc(labelValues = [dialFailure])
       return err("no suitable remote peers")
 


### PR DESCRIPTION
This minimal PR partially addresses https://github.com/status-im/nwaku/issues/983

It cleans up unnecessary logging, correct misleading `ERROR` logs and lower log levels where necessary.

Specifically, it:
- avoids the unnecessary error condition where the peer manager tries to store information for a connecting/disconnecting peer that is not tracked in the store (resulted in both error metrics and logs).
- lowers the per-message log level for nodes with RLN enabled, especially when few messages match the RLN content topic (currently RLN logs all messages at `DEBUG` level on the `wakuv2.test` fleet)
- avoids misleading `ERROR: Retrieving dynamic bootstrap nodes failed` by having an empty bootstrap list be an acceptable condition
- lowers error-level warning for `store` nodes starting with no static `store` peers configured to resume history from - many nodes start like this (i.e. with no desire to `resume`).