### PR TITLE
chore: adjust dyn bootstrap error message

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -1066,6 +1066,10 @@ when isMainModule:
           .mapErr(proc (e: cstring): string = $e)
       else:
         warn "Failed to init Waku DNS discovery"
+    # no dynamic bootstrap method specified
+    else:
+      debug "No method for retrieving dynamic bootstrap nodes specified."
+      return SetupResult[seq[RemotePeerInfo]].ok(@[])
 
   # 3/7 Initialize node
   proc initNode(conf: WakuNodeConf,
@@ -1342,7 +1346,7 @@ when isMainModule:
   var dynamicBootstrapNodes: seq[RemotePeerInfo]
   let dynamicBootstrapNodesRes = retrieveDynamicBootstrapNodes(conf)
   if dynamicBootstrapNodesRes.isErr:
-    error "2/7 Retrieving dynamic bootstrap nodes failed. Continuing without dynamic bootstrap nodes."
+    warn "2/7 Retrieving dynamic bootstrap nodes failed. Continuing without dynamic bootstrap nodes."
   else:
     dynamicBootstrapNodes = dynamicBootstrapNodesRes.get()
 


### PR DESCRIPTION
Continuation of #991

This PR adjusts the message printed when dynamic bootstrap nodes were found, differentiation between an INFO when no method was specified and a WRN if looking up dynamic bootstrap nodes failed.

##  Info / Questions

We could print an ERR, if no bootstrap nodes are available at all (including static ones).