### PR TITLE
ci: add timeouts to Jenkins pipelines

### DIFF
--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -28,7 +28,9 @@ pipeline {
 
   options {
     timestamps()
-    /* manage how many builds we keep */
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 30, unit: 'MINUTES')
+    /* Limit builds retained. */
     buildDiscarder(logRotator(
       numToKeepStr: '3',
       daysToKeepStr: '30',

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -3,6 +3,8 @@ pipeline {
 
   options {
     timestamps()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 20, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',


### PR DESCRIPTION
We've seen a few jobs running on MacOS hosts stuck for days:

* https://ci.status.im/job/nim-waku/job/prs/job/macos/job/PR-982/ - [7 days 7 hr](https://ci.status.im/job/nim-waku/job/prs/job/macos/job/PR-982/buildTimeTrend)
* https://ci.status.im/job/nim-waku/job/prs/job/macos/job/PR-979/ - [5 days 7 hr](https://ci.status.im/job/nim-waku/job/prs/job/macos/job/PR-979/buildTimeTrend)

Which is not acceptable.