### PR TITLE
fix: encode protobuffers using proto3

### DIFF
--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -13,6 +13,7 @@ import
   libp2p/crypto/crypto,
   waku_filter_types,
   ../../utils/requests,
+  ../../utils/protobuf,
   ../../node/peer_manager/peer_manager
 
 # NOTE This is just a start, the design of this protocol isn't done yet. It
@@ -77,18 +78,23 @@ proc unsubscribeFilters(subscribers: var seq[Subscriber], request: FilterRequest
 proc encode*(filter: ContentFilter): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, filter.contentTopic)
+  output.write3(1, filter.contentTopic)
+
+  output.finish3()
+
   return output
 
 proc encode*(rpc: FilterRequest): ProtoBuffer =
   var output = initProtoBuffer()
   
-  output.write(1, uint64(rpc.subscribe))
+  output.write3(1, uint64(rpc.subscribe))
 
-  output.write(2, rpc.pubSubTopic)
+  output.write3(2, rpc.pubSubTopic)
 
   for filter in rpc.contentFilters:
-    output.write(3, filter.encode())
+    output.write3(3, filter.encode())
+
+  output.finish3()
 
   return output
 
@@ -122,7 +128,9 @@ proc encode*(push: MessagePush): ProtoBuffer =
   var output = initProtoBuffer()
 
   for push in push.messages:
-    output.write(1, push.encode())
+    output.write3(1, push.encode())
+
+  output.finish3()
 
   return output
 
@@ -159,9 +167,11 @@ proc init*(T: type FilterRPC, buffer: seq[byte]): ProtoResult[T] =
 proc encode*(rpc: FilterRPC): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, rpc.requestId)
-  output.write(2, rpc.request.encode())
-  output.write(3, rpc.push.encode())
+  output.write3(1, rpc.requestId)
+  output.write3(2, rpc.request.encode())
+  output.write3(3, rpc.push.encode())
+
+  output.finish3()
 
   return output
 

--- a/waku/v2/protocol/waku_lightpush/waku_lightpush.nim
+++ b/waku/v2/protocol/waku_lightpush/waku_lightpush.nim
@@ -13,6 +13,7 @@ import
   libp2p/crypto/crypto,
   waku_lightpush_types,
   ../../utils/requests,
+  ../../utils/protobuf,
   ../../node/peer_manager/peer_manager,
   ../waku_relay
 
@@ -37,8 +38,10 @@ const
 proc encode*(rpc: PushRequest): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, rpc.pubSubTopic)
-  output.write(2, rpc.message.encode())
+  output.write3(1, rpc.pubSubTopic)
+  output.write3(2, rpc.message.encode())
+
+  output.finish3()
 
   return output
 
@@ -60,8 +63,10 @@ proc init*(T: type PushRequest, buffer: seq[byte]): ProtoResult[T] =
 proc encode*(rpc: PushResponse): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, uint64(rpc.isSuccess))
-  output.write(2, rpc.info)
+  output.write3(1, uint64(rpc.isSuccess))
+  output.write3(2, rpc.info)
+
+  output.finish3()
 
   return output
 
@@ -82,9 +87,11 @@ proc init*(T: type PushResponse, buffer: seq[byte]): ProtoResult[T] =
 proc encode*(rpc: PushRPC): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, rpc.requestId)
-  output.write(2, rpc.request.encode())
-  output.write(3, rpc.response.encode())
+  output.write3(1, rpc.requestId)
+  output.write3(2, rpc.request.encode())
+  output.write3(3, rpc.response.encode())
+
+  output.finish3()
 
   return output
 

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -11,6 +11,7 @@
 import
   libp2p/protobuf/minprotobuf,
   libp2p/varint,
+  ../utils/protobuf,
   ../utils/time,
   waku_rln_relay/waku_rln_relay_types
 
@@ -56,9 +57,11 @@ proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
 proc encode*(message: WakuMessage): ProtoBuffer =
   result = initProtoBuffer()
 
-  result.write(1, message.payload)
-  result.write(2, message.contentTopic)
-  result.write(3, message.version)
-  result.write(10, zint64(message.timestamp))
-  result.write(21, message.proof.encode())
+  result.write3(1, message.payload)
+  result.write3(2, message.contentTopic)
+  result.write3(3, message.version)
+  result.write3(10, zint64(message.timestamp))
+  result.write3(21, message.proof.encode())
+  
+  result.finish3()
 

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -6,7 +6,8 @@ import
   web3,
   eth/keys,
   libp2p/protobuf/minprotobuf,
-  stew/arrayops
+  stew/arrayops,
+  ../../utils/protobuf
 
 ## Bn256 and RLN are Nim wrappers for the data types used in
 ## the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
@@ -355,11 +356,13 @@ proc init*(T: type RateLimitProof, buffer: seq[byte]): ProtoResult[T] =
 proc encode*(nsp: RateLimitProof): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, nsp.proof)
-  output.write(2, nsp.merkleRoot)
-  output.write(3, nsp.epoch)
-  output.write(4, nsp.shareX)
-  output.write(5, nsp.shareY)
-  output.write(6, nsp.nullifier)
+  output.write3(1, nsp.proof)
+  output.write3(2, nsp.merkleRoot)
+  output.write3(3, nsp.epoch)
+  output.write3(4, nsp.shareX)
+  output.write3(5, nsp.shareY)
+  output.write3(6, nsp.nullifier)
+
+  output.finish3()
 
   return output

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -22,6 +22,7 @@ import
   # internal imports
   ../../node/storage/message/message_store,
   ../../node/peer_manager/peer_manager,
+  ../../utils/protobuf,
   ../../utils/requests,
   ../../utils/time,
   ../waku_swap/waku_swap,
@@ -98,10 +99,12 @@ proc encode*(index: Index): ProtoBuffer =
   var output = initProtoBuffer()
 
   # encodes index
-  output.write(1, index.digest.data)
-  output.write(2, zint64(index.receiverTime))
-  output.write(3, zint64(index.senderTime))
-  output.write(4, index.pubsubTopic)
+  output.write3(1, index.digest.data)
+  output.write3(2, zint64(index.receiverTime))
+  output.write3(3, zint64(index.senderTime))
+  output.write3(4, index.pubsubTopic)
+
+  output.finish3()
 
   return output
 
@@ -113,9 +116,11 @@ proc encode*(pinfo: PagingInfo): ProtoBuffer =
   var output = initProtoBuffer()
 
   # encodes pinfo
-  output.write(1, pinfo.pageSize)
-  output.write(2, pinfo.cursor.encode())
-  output.write(3, uint32(ord(pinfo.direction)))
+  output.write3(1, pinfo.pageSize)
+  output.write3(2, pinfo.cursor.encode())
+  output.write3(3, uint32(ord(pinfo.direction)))
+
+  output.finish3()
 
   return output
 
@@ -243,21 +248,24 @@ proc init*(T: type HistoryRPC, buffer: seq[byte]): ProtoResult[T] =
 
 proc encode*(filter: HistoryContentFilter): ProtoBuffer =
   var output = initProtoBuffer()
-  output.write(1, filter.contentTopic)
+  output.write3(1, filter.contentTopic)
+  output.finish3()
   return output
 
 proc encode*(query: HistoryQuery): ProtoBuffer =
   var output = initProtoBuffer()
   
-  output.write(2, query.pubsubTopic)
+  output.write3(2, query.pubsubTopic)
 
   for filter in query.contentFilters:
-    output.write(3, filter.encode())
+    output.write3(3, filter.encode())
 
-  output.write(4, query.pagingInfo.encode())
+  output.write3(4, query.pagingInfo.encode())
 
-  output.write(5, zint64(query.startTime))
-  output.write(6, zint64(query.endTime))
+  output.write3(5, zint64(query.startTime))
+  output.write3(6, zint64(query.endTime))
+
+  output.finish3()
 
   return output
 
@@ -265,20 +273,24 @@ proc encode*(response: HistoryResponse): ProtoBuffer =
   var output = initProtoBuffer()
 
   for msg in response.messages:
-    output.write(2, msg.encode())
+    output.write3(2, msg.encode())
 
-  output.write(3, response.pagingInfo.encode())
+  output.write3(3, response.pagingInfo.encode())
 
-  output.write(4, uint32(ord(response.error)))
+  output.write3(4, uint32(ord(response.error)))
+
+  output.finish3()
 
   return output
 
 proc encode*(rpc: HistoryRPC): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, rpc.requestId)
-  output.write(2, rpc.query.encode())
-  output.write(3, rpc.response.encode())
+  output.write3(1, rpc.requestId)
+  output.write3(2, rpc.query.encode())
+  output.write3(3, rpc.response.encode())
+
+  output.finish3()
 
   return output
 

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -42,6 +42,7 @@ import
   libp2p/stream/connection,
   ../../node/peer_manager/peer_manager,
   ./waku_swap_types,
+  ../../utils/protobuf,
   ../../waku/v2/protocol/waku_swap/waku_swap_contracts
 
 export waku_swap_types
@@ -68,17 +69,21 @@ const
 proc encode*(handshake: Handshake): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, handshake.beneficiary)
+  output.write3(1, handshake.beneficiary)
+
+  output.finish3()
 
   return output
 
 proc encode*(cheque: Cheque): ProtoBuffer =
   var output = initProtoBuffer()
 
-  output.write(1, cheque.beneficiary)
-  output.write(2, cheque.date)
-  output.write(3, cheque.amount)
-  output.write(4, cheque.signature)
+  output.write3(1, cheque.beneficiary)
+  output.write3(2, cheque.date)
+  output.write3(3, cheque.amount)
+  output.write3(4, cheque.signature)
+
+  output.finish3()
 
   return output
 

--- a/waku/v2/utils/protobuf.nim
+++ b/waku/v2/utils/protobuf.nim
@@ -1,0 +1,20 @@
+{.push raises: [Defect].}
+
+import
+  libp2p/protobuf/minprotobuf,
+  libp2p/varint
+
+# Collection of utilities related to protobuffer encoding
+
+proc write3*(proto: var ProtoBuffer, field: int, value: auto) =
+  if default(type(value)) != value:
+    proto.write(field, value)
+
+proc finish3*(proto: var ProtoBuffer) =
+  if proto.buffer.len > 0:
+    proto.finish()
+  else:
+    proto.offset = 0
+
+proc `==`*(a: zint64, b: zint64): bool =
+  int64(a) == int64(b)


### PR DESCRIPTION
Currently protobuffers are being encoded using `proto2`, while on the specs `proto3` is the version meant to be used, This results in null/empty fields being written in the buffer. i.e: the following WakuMessage:
```
payload: @[1, 2, 3, 4],
contentTopic: "hola",
version:      0,
timestamp:    12345,
```
Is generating this byte array: 
```
[10, 4, 1, 2, 3, 4, 18, 4, 104, 111, 108, 97, 24, 0, 80, 242, 192, 1, 170, 1, 173, 3, 10, 128, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 26, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 34, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
```
matching `proto2` specs,  while if they were encoded using `proto3`, the following output would be generated:
```
[10, 4, 1, 2, 3, 4, 18, 4, 104, 111, 108, 97, 80, 242, 192, 1]
```
which is more efficient (less bytes being transmitted), since it does not include the empty fields (see:  https://developers.google.com/protocol-buffers/docs/proto3#default).

This PR introduces new functions:  `write3` and `finish3` which should be used instead of `write` and `finish` when encoding a protobuffer with `proto3`. It also fixes some instances of protobuffers being encoded without calling .finish()

@D4nte, this will require a change in js-waku to handle empty/default values, since right now a field that's not present in the byte array for a protobuffer is assumed to be undefined (like in proto2), and it should instead return the default value for a field type.