### PR TITLE
Fixed handling of bindParam(uint32) in sqlite.nim

### DIFF
--- a/waku/v2/node/storage/sqlite.nim
+++ b/waku/v2/node/storage/sqlite.nim
@@ -136,7 +136,7 @@ proc bindParam*(s: RawStmtPtr, n: int, val: auto): cint =
   elif val is int32:
     sqlite3_bind_int(s, n.cint, val)
   elif val is uint32:
-    sqlite3_bind_int(s, int(n).cint, int(val).cint)
+    sqlite3_bind_int64(s, n.cint, val)
   elif val is int64:
     sqlite3_bind_int64(s, n.cint, val)
   elif val is float64:


### PR DESCRIPTION
1. n is already int
2. when val >= 1<<31, using sqlite3_bind_int should store it as negative value