### PR TITLE
fix(store): limit dbPageSize

### DIFF
--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -273,7 +273,8 @@ proc adjustDbPageSize(dbPageSize: uint64, matchCount: uint64, returnPageSize: ui
   var ret =
     if matchCount < 2: dbPageSize * returnPageSize
     else: dbPageSize * (returnPageSize div matchCount)
-  if ret >= maxDbPageSize: ret = maxDbPageSize
+  if ret >= maxDbPageSize:
+    ret = maxDbPageSize
   trace "dbPageSize adjusted to: ",  ret
   ret
 

--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -267,8 +267,12 @@ method getAll*(db: WakuMessageStore, onData: message_store.DataProc): MessageSto
   ok gotMessages
 
 proc adjustDbPageSize(dbPageSize: uint64, matchCount: uint64, returnPageSize: uint64): uint64 {.inline.} =
-  var ret = if matchCount < 2: dbPageSize * returnPageSize
+  const maxDbPageSize: uint64 = 20000 # the maximum DB page size is limited to prevent excessive use of memory in case of very sparse or non-matching filters. TODO: dynamic, adjust to available memory
+  if dbPageSize >= maxDbPageSize: return maxDbPageSize
+  var ret =
+    if matchCount < 2: dbPageSize * returnPageSize
     else: dbPageSize * (returnPageSize div matchCount)
+  if ret >= maxDbPageSize: ret = maxDbPageSize
   trace "dbPageSize adjusted to: ",  ret
   ret
 

--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -273,8 +273,7 @@ proc adjustDbPageSize(dbPageSize: uint64, matchCount: uint64, returnPageSize: ui
   var ret =
     if matchCount < 2: dbPageSize * returnPageSize
     else: dbPageSize * (returnPageSize div matchCount)
-  if ret >= maxDbPageSize:
-    ret = maxDbPageSize
+  ret = min(ret, maxDbPageSize)
   trace "dbPageSize adjusted to: ",  ret
   ret
 

--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -268,7 +268,8 @@ method getAll*(db: WakuMessageStore, onData: message_store.DataProc): MessageSto
 
 proc adjustDbPageSize(dbPageSize: uint64, matchCount: uint64, returnPageSize: uint64): uint64 {.inline.} =
   const maxDbPageSize: uint64 = 20000 # the maximum DB page size is limited to prevent excessive use of memory in case of very sparse or non-matching filters. TODO: dynamic, adjust to available memory
-  if dbPageSize >= maxDbPageSize: return maxDbPageSize
+  if dbPageSize >= maxDbPageSize: 
+    return maxDbPageSize
   var ret =
     if matchCount < 2: dbPageSize * returnPageSize
     else: dbPageSize * (returnPageSize div matchCount)


### PR DESCRIPTION
This PR limits `dbPageSize` avoiding excessive use of memory in case of sparse or non-matching filters.
This PR partly solves #1017 