### PR TITLE
Feat (Rln relay): enabling signed tx

### DIFF
--- a/tests/v2/test_waku_rln_relay_onchain.nim
+++ b/tests/v2/test_waku_rln_relay_onchain.nim
@@ -285,7 +285,9 @@ procSuite "Waku-rln-relay":
     check: 
       membershipKeyPair.isSome
 
+    # create an Ethereum private key and the corresponding account 
     let (ethPrivKey, ethacc) = await createEthAccount()
+
     # test ------------------------------
     # initialize the WakuRLNRelay
     var rlnPeer = WakuRLNRelay(membershipKeyPair: membershipKeyPair.get(),
@@ -419,11 +421,13 @@ procSuite "Waku-rln-relay":
     let tx2Hash = await contractObj.register(pk2).send(value = MEMBERSHIP_FEE)
     debug "a member is registered", tx2 = tx2Hash
 
+     # create an Ethereum private key and the corresponding account 
+    let (ethPrivKey, ethacc) = await createEthAccount()
+
+
     # test ------------------------------
     # start rln-relay
     node.mountRelay(@[RLNRELAY_PUBSUB_TOPIC])
-
-    let (ethPrivKey, ethacc) = await createEthAccount()
     await node.mountRlnRelayDynamic(ethClientAddr = EthClient,
                             ethAccAddr = ethacc,
                             ethAccountPrivKey = ethPrivKey,
@@ -472,9 +476,11 @@ procSuite "Waku-rln-relay":
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60001))
     await node2.start()
 
+     # create an Ethereum private key and the corresponding account 
+    let (ethPrivKey, ethacc) = await createEthAccount()
+
     # start rln-relay on the first node, leave rln-relay credentials empty
     node.mountRelay(@[RLNRELAY_PUBSUB_TOPIC])
-    let (ethPrivKey, ethacc) = await createEthAccount()
     await node.mountRlnRelayDynamic(ethClientAddr = EthClient,
                             ethAccAddr = ethacc,
                             ethAccountPrivKey = ethPrivKey,

--- a/tests/v2/test_waku_rln_relay_onchain.nim
+++ b/tests/v2/test_waku_rln_relay_onchain.nim
@@ -7,6 +7,7 @@ import
   testutils/unittests, chronos, chronicles, stint, web3, json,
   stew/byteutils, stew/shims/net as stewNet,
   libp2p/crypto/crypto,
+  eth/keys,
   ../../waku/v2/protocol/waku_rln_relay/[waku_rln_relay_utils,
       waku_rln_relay_types, rln_relay_contract],
   ../../waku/v2/node/wakunode2,
@@ -74,6 +75,31 @@ proc uploadRLNContract*(ethClientAddress: string): Future[Address] {.async.} =
   debug "disconnected from ", ethClientAddress
 
   return contractAddress
+
+
+proc createEthAccount(): Future[(keys.PrivateKey, Address)] {.async.} =
+  let theRNG = keys.newRng()
+
+  let web3 = await newWeb3(ETH_CLIENT)
+  let accounts = await web3.provider.eth_accounts()
+  let gasPrice = int(await web3.provider.eth_gasPrice())
+  web3.defaultAccount = accounts[0]
+
+  let pk = keys.PrivateKey.random(theRNG[])
+  let acc = Address(toCanonicalAddress(pk.toPublicKey()))
+
+  var tx: EthSend
+  tx.source = accounts[0]
+  tx.value = some(ethToWei(10.u256))
+  tx.to = some(acc)
+  tx.gasPrice = some(gasPrice)
+
+  # Send 10 eth to acc
+  discard await web3.send(tx)
+  var balance = await web3.provider.eth_getBalance(acc, "latest")
+  assert(balance == ethToWei(10.u256))
+
+  return (pk, acc)
 
 procSuite "Waku-rln-relay":
   asyncTest "event subscription":
@@ -347,6 +373,8 @@ procSuite "Waku-rln-relay":
       # choose one of the existing accounts for the rln-relay peer
       ethAccountAddress = accounts[0]
     web3.defaultAccount = accounts[0]
+    
+  
 
     # create an rln instance
     var rlnInstance = createRLNInstance()
@@ -392,8 +420,11 @@ procSuite "Waku-rln-relay":
     # test ------------------------------
     # start rln-relay
     node.mountRelay(@[RLNRELAY_PUBSUB_TOPIC])
+
+    let (ethPrivKey, ethacc) = await createEthAccount()
     await node.mountRlnRelayDynamic(ethClientAddr = EthClient,
-                            ethAccAddr = ethAccountAddress,
+                            ethAccAddr = ethacc,
+                            ethAccountPrivKey = ethPrivKey,
                             memContractAddr = contractAddress, 
                             memKeyPair = keyPair1,
                             memIndex = some(MembershipIndex(0)),
@@ -441,8 +472,10 @@ procSuite "Waku-rln-relay":
 
     # start rln-relay on the first node, leave rln-relay credentials empty
     node.mountRelay(@[RLNRELAY_PUBSUB_TOPIC])
+    let (ethPrivKey, ethacc) = await createEthAccount()
     await node.mountRlnRelayDynamic(ethClientAddr = EthClient,
-                            ethAccAddr = ethAccountAddress1,
+                            ethAccAddr = ethacc,
+                            ethAccountPrivKey = ethPrivKey,
                             memContractAddr = contractAddress, 
                             memKeyPair = none(MembershipKeyPair),
                             memIndex = none(MembershipIndex),
@@ -454,7 +487,8 @@ procSuite "Waku-rln-relay":
     # start rln-relay on the second node, leave rln-relay credentials empty
     node2.mountRelay(@[RLNRELAY_PUBSUB_TOPIC])
     await node2.mountRlnRelayDynamic(ethClientAddr = EthClient,
-                            ethAccAddr = ethAccountAddress2,
+                            ethAccAddr = ethacc,
+                            ethAccountPrivKey = ethPrivKey,
                             memContractAddr = contractAddress, 
                             memKeyPair = none(MembershipKeyPair),
                             memIndex = none(MembershipIndex),

--- a/tests/v2/test_waku_rln_relay_onchain.nim
+++ b/tests/v2/test_waku_rln_relay_onchain.nim
@@ -285,12 +285,14 @@ procSuite "Waku-rln-relay":
     check: 
       membershipKeyPair.isSome
 
+    let (ethPrivKey, ethacc) = await createEthAccount()
     # test ------------------------------
     # initialize the WakuRLNRelay
     var rlnPeer = WakuRLNRelay(membershipKeyPair: membershipKeyPair.get(),
       membershipIndex: MembershipIndex(0),
       ethClientAddress: ETH_CLIENT,
-      ethAccountAddress: ethAccountAddress,
+      ethAccountPrivateKey: ethPrivKey,
+      ethAccountAddress: ethacc,
       membershipContractAddress: contractAddress)
 
     # register the rln-relay peer to the membership contract

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -151,7 +151,7 @@ type
       name: "eth-account-address" }: string
 
     rlnRelayEthAccountPrivKey* {.
-      desc: "Account private key for  Goerli",
+      desc: "Account private key for the Ethereum testnet Goerli",
       defaultValue: ""
       name: "eth-account-privatekey" }: string
     

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -146,12 +146,12 @@ type
       name: "rln-relay-id-commitment" }: string
   
     rlnRelayEthAccount* {.
-      desc: "Account address for Ethereum testnet Goerli", 
+      desc: "Account address for the Ethereum testnet Goerli", 
       defaultValue: ""
       name: "eth-account-address" }: string
 
     rlnRelayEthAccountPrivKey* {.
-      desc: "Account private key for Ethereum testnet Goerli",
+      desc: "Account private key for the Ethereum testnet Goerli",
       defaultValue: ""
       name: "eth-account-privatekey" }: string
     

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -149,6 +149,11 @@ type
       desc: "Ethereum testnet account address", 
       defaultValue: ""
       name: "eth-account-address" }: string
+
+    rlnRelayEthAccountPrivKey* {.
+      desc: "Ethereum testnet account private key",
+      defaultValue: ""
+      name: "eth-account-privatekey" }: string
     
     rlnRelayEthClientAddress* {.
       desc: "Ethereum testnet client address e.g., ws://localhost:8540/",

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -146,12 +146,12 @@ type
       name: "rln-relay-id-commitment" }: string
   
     rlnRelayEthAccount* {.
-      desc: "Ethereum testnet account address", 
+      desc: "Account address for Ethereum testnet Goerli", 
       defaultValue: ""
       name: "eth-account-address" }: string
 
     rlnRelayEthAccountPrivKey* {.
-      desc: "Ethereum testnet account private key",
+      desc: "Account private key for Ethereum testnet Goerli",
       defaultValue: ""
       name: "eth-account-privatekey" }: string
     

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -151,7 +151,7 @@ type
       name: "eth-account-address" }: string
 
     rlnRelayEthAccountPrivKey* {.
-      desc: "Account private key for the Ethereum testnet Goerli",
+      desc: "Account private key for  Goerli",
       defaultValue: ""
       name: "eth-account-privatekey" }: string
     

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -91,7 +91,7 @@ type MessageValidationResult* {.pure.} = enum
 # TODO may be able to make these constants private and put them inside the waku_rln_relay_utils
 const
   MEMBERSHIP_FEE* = 1000000000000000.u256
-  #  the current implementation of the rln lib only supports a circuit for Merkle tree with depth 32
+  #  the current implementation of the rln lib supports a circuit for Merkle tree with depth 20
   MERKLE_TREE_DEPTH* = 20
   # TODO the ETH_CLIENT should be an input to the rln-relay, though hardcoded for now
   # the current address is the address of ganache-cli when run locally

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -90,7 +90,7 @@ type MessageValidationResult* {.pure.} = enum
 # inputs of the membership contract constructor
 # TODO may be able to make these constants private and put them inside the waku_rln_relay_utils
 const
-  MEMBERSHIP_FEE* = 5.u256
+  MEMBERSHIP_FEE* = 1000000000000000.u256
   #  the current implementation of the rln lib only supports a circuit for Merkle tree with depth 32
   MERKLE_TREE_DEPTH* = 20
   # TODO the ETH_CLIENT should be an input to the rln-relay, though hardcoded for now

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -630,8 +630,6 @@ proc subscribeToGroupEvents(ethClientUri: string, ethAccountAddress: Address, co
   discard await contractObj.subscribe(MemberRegistered, %*{"fromBlock": blockNumber, "address": contractAddress}) do(pubkey: Uint256, index: Uint256){.raises: [Defect], gcsafe.}:
     try:
       debug "onRegister", pubkey = pubkey, index = index
-      echo "onRegister",  pubkey,  index
-
       handler(pubkey, index)
     except Exception as err:
       # chronos still raises exceptions which inherit directly from Exception

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -119,11 +119,13 @@ proc toMembershipIndex(v: UInt256): MembershipIndex =
   let result: MembershipIndex = cast[MembershipIndex](v)
   return result
 
-proc register*(idComm: IDCommitment, ethAccountAddress: Address, ethClientAddress: string, membershipContractAddress: Address): Future[Result[MembershipIndex, string]] {.async.} =
+proc register*(idComm: IDCommitment, ethAccountAddress: Address, ethAccountPrivKey: keys.PrivateKey, ethClientAddress: string, membershipContractAddress: Address): Future[Result[MembershipIndex, string]] {.async.} =
   # TODO may need to also get eth Account Private Key as PrivateKey
   ## registers the idComm  into the membership contract whose address is in rlnPeer.membershipContractAddress
   let web3 = await newWeb3(ethClientAddress)
   web3.defaultAccount = ethAccountAddress
+  # set the account private key
+  web3.privateKey = some(ethAccountPrivKey)
   
   # when the private key is set in a web3 instance, the send proc (sender.register(pk).send(MEMBERSHIP_FEE))
   # does the signing using the provided key

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -611,22 +611,27 @@ proc addAll*(rlnInstance: RLN[Bn256], list: seq[IDCommitment]): bool =
 type RegistrationEventHandler  = proc(pubkey: Uint256, index: Uint256): void {.gcsafe, closure, raises: [Defect].}
 
 
-proc subscribeToGroupEvents(ethClientUri: string, contractAddress: Address, blockNumber: string = "0x0", handler: RegistrationEventHandler) {.async, gcsafe.} = 
+proc subscribeToGroupEvents(ethClientUri: string, ethAccountAddress: Address, contractAddress: Address, blockNumber: string = "0x0", handler: RegistrationEventHandler) {.async, gcsafe.} = 
   ## connects to the eth client whose URI is supplied as `ethClientUri`
   ## subscribes to the `MemberRegistered` event emitted from the `MembershipContract` which is available on the supplied `contractAddress`
   ## it collects all the events starting from the given `blockNumber`
   ## for every received event, it calls the `handler`
   
   # connect to the eth client
-  let web3 = await newWeb3(ETH_CLIENT)
+  let web3 = await newWeb3(ethClientUri)
   # prepare a contract sender to interact with it
   var contractObj = web3.contractSender(MembershipContract, contractAddress) 
+  web3.defaultAccount = ethAccountAddress 
+  #  set the gas price twice the suggested price in order for the fast mining
+  # let gasPrice = int(await web3.provider.eth_gasPrice()) * 2
 
   # subscribe to the MemberRegistered events
   # TODO can do similarly for deletion events, though it is not yet supported
   discard await contractObj.subscribe(MemberRegistered, %*{"fromBlock": blockNumber, "address": contractAddress}) do(pubkey: Uint256, index: Uint256){.raises: [Defect], gcsafe.}:
     try:
       debug "onRegister", pubkey = pubkey, index = index
+      echo "onRegister",  pubkey,  index
+
       handler(pubkey, index)
     except Exception as err:
       # chronos still raises exceptions which inherit directly from Exception
@@ -636,7 +641,7 @@ proc subscribeToGroupEvents(ethClientUri: string, contractAddress: Address, bloc
 
 proc handleGroupUpdates*(rlnPeer: WakuRLNRelay, handler: RegistrationEventHandler) {.async, gcsafe.} =
   # mounts the supplied handler for the registration events emitting from the membership contract
-  await subscribeToGroupEvents(ethClientUri = rlnPeer.ethClientAddress, contractAddress = rlnPeer.membershipContractAddress, handler = handler) 
+  await subscribeToGroupEvents(ethClientUri = rlnPeer.ethClientAddress, ethAccountAddress = rlnPeer.ethAccountAddress, contractAddress = rlnPeer.membershipContractAddress, handler = handler) 
 
 proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: string, contentTopic: ContentTopic, spamHandler: Option[SpamHandler] = none(SpamHandler)) =
   ## this procedure is a thin wrapper for the pubsub addValidator method
@@ -790,6 +795,7 @@ proc mountRlnRelayDynamic*(node: WakuNode,
     membershipContractAddress: memContractAddr,
     ethClientAddress: ethClientAddr,
     ethAccountAddress: ethAccAddr,
+    ethAccountPrivateKey: ethAccountPrivKey,
     rlnInstance: rln,
     pubsubTopic: pubsubTopic,
     contentTopic: contentTopic)


### PR DESCRIPTION
The rln-relay nodes require to sign their registration transactions to authorize the fund deduction from their ethereum accounts. This PR integrates the signing feature alongside with a CLI option to pass the Ethereum private key. 
Note that passing the Ethereum account private key is an MVP solution just for testing purposes and in no way is secure, however, it is tolerable for now as all the interactions take place on the Ethereum testnet Goerli with no actual fund involved.

Note that as part of this PR, the on-chain rln-relay tests needed to be updated to account for the Eth private key requirement. 

Next Step: https://github.com/status-im/nwaku/issues/819