### PR TITLE
perf(store): remove vacuum

### DIFF
--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -100,11 +100,6 @@ proc deleteOldest(db: WakuMessageStore): MessageStoreResult[void] =
     let numMessages = messageCount(db.database).get() # requires another SELECT query, so only run in debug mode
     debug "Number of messages left after delete operation.", messagesLeft=numMessages
 
-  # reduce the size of the DB file after the delete operation. See: https://www.sqlite.org/lang_vacuum.html
-  let resVacuum = db.database.query("vacuum", proc(s: ptr sqlite3_stmt) = discard)
-  if resVacuum.isErr:
-    return err("vacuum after delete was not successful: " & resVacuum.error)
-
   ok()
 
 proc init*(T: type WakuMessageStore, db: SqliteDatabase, storeCapacity: int = 50000, isSqliteOnly = false, retentionTime = chronos.days(30).seconds): MessageStoreResult[T] =


### PR DESCRIPTION
[Vacuum is an expensive operation](https://wiki.mozilla.org/Firefox/Projects/Places_Vacuum#Vacuum_timings).
This PR removes vacuum from the batch delete operation in the store.
For now, we rather vacuum "manually".
In the future we could run vacuum in a timer task.

See #1024 