### PR TITLE
chore: remove unused imports

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -6,7 +6,7 @@ when not(compileOption("threads")):
 
 {.push raises: [Defect].}
 
-import std/[tables, strformat, strutils, times, httpclient, json, sequtils, random, options]
+import std/[tables, strformat, strutils, times, json, options]
 import confutils, chronicles, chronos, stew/shims/net as stewNet,
        eth/keys, bearssl, stew/[byteutils, endians2, results],
        nimcrypto/pbkdf2
@@ -31,8 +31,7 @@ when defined(rln):
   import
     libp2p/protocols/pubsub/rpc/messages,
     libp2p/protocols/pubsub/pubsub,
-    web3,
-    ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils]
+    ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils
 
 const Help = """
   Commands: /[?|help|connect|nick|exit]

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -25,8 +25,7 @@ import
   ../../waku/v2/protocol/waku_swap/waku_swap,
   ../../waku/v2/protocol/waku_filter/waku_filter,
   ../../waku/v2/utils/peers,
-  ../../waku/v2/utils/time,
-  ../test_helpers
+  ../../waku/v2/utils/time
 
 template sourceDir*: string = currentSourcePath.rsplit(DirSep, 1)[0]
 const sigPath = sourceDir / ParDir / ParDir / "waku" / "v2" / "node" / "jsonrpc" / "jsonrpc_callsigs.nim"

--- a/tests/v2/test_migration_utils.nim
+++ b/tests/v2/test_migration_utils.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[unittest, tables, strutils, os, sequtils],
+  std/[unittest, tables, strutils, os],
   chronicles,
   stew/results,
   ../../waku/v2/node/storage/migration/migration_utils

--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[tables, sequtils],
+  std/tables,
   chronicles,
   chronos,
   testutils/unittests,

--- a/tests/v2/test_waku_pagination.nim
+++ b/tests/v2/test_waku_pagination.nim
@@ -1,11 +1,10 @@
 {.used.}
 import
-  std/[algorithm, options, sequtils],
+  std/[options, sequtils],
   testutils/unittests, nimcrypto/sha2,
   libp2p/protobuf/minprotobuf,
   ../../waku/v2/protocol/waku_store/waku_store,
-  ../../waku/v2/utils/time,
-  ../test_helpers
+  ../../waku/v2/utils/time
 
 
 proc createSampleStoreQueue(s: int): StoreQueueRef =

--- a/tests/v2/test_waku_payload.nim
+++ b/tests/v2/test_waku_payload.nim
@@ -3,8 +3,7 @@
 import
   testutils/unittests,
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/node/waku_payload,
-  ../test_helpers
+  ../../waku/v2/node/waku_payload
 
 procSuite "Waku Payload":
   let rng = newRng()

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -3,14 +3,13 @@
 
 import
   std/options, sequtils, times,
-  testutils/unittests, chronos, chronicles, stint, web3,
+  testutils/unittests, chronos, chronicles, stint,
   stew/byteutils, stew/shims/net as stewNet,
   libp2p/crypto/crypto,
   ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils,
       waku_rln_relay_types],
   ../../waku/v2/node/wakunode2,
-  ../test_helpers,
-  ./test_utils
+  ../test_helpers
 
 const RLNRELAY_PUBSUB_TOPIC = "waku/2/rlnrelay/proto"
 const RLNRELAY_CONTENT_TOPIC = "waku/2/rlnrelay/proto"

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -2,7 +2,6 @@
 
 import
   testutils/unittests,
-  std/sequtils,
   chronicles, chronos, stew/shims/net as stewNet, stew/byteutils, std/os,
   libp2p/crypto/crypto,
   libp2p/crypto/secp,
@@ -23,10 +22,10 @@ import
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
   ../../waku/v2/utils/time,
-  ../../waku/v2/node/wakunode2,
-  ../test_helpers
+  ../../waku/v2/node/wakunode2
 
 when defined(rln):
+  import std/sequtils
   import 
     ../../waku/v2/protocol/waku_rln_relay/[waku_rln_relay_utils, waku_rln_relay_types]
   from times import epochTime

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -323,7 +323,6 @@ when isMainModule:
     ../v1/node/rpc/wakusim,
     ../v1/node/rpc/waku,
     ../v1/node/rpc/key_storage,
-    ../v1/node/waku_helpers,
     ../v2/node/jsonrpc/[debug_api,
                         filter_api,
                         relay_api,

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -8,7 +8,6 @@ import
   libp2p/crypto/secp,
   nimcrypto/utils,
   eth/keys,
-  web3,
   ../protocol/waku_rln_relay/waku_rln_relay_types,
   ../protocol/waku_message
 

--- a/waku/v2/node/discv5/waku_discv5.nim
+++ b/waku/v2/node/discv5/waku_discv5.nim
@@ -1,7 +1,7 @@
 {.push raises: [Defect].}
 
 import
-  std/[sequtils, strutils, options],
+  std/[strutils, options],
   chronos, chronicles, metrics,
   eth/keys,
   eth/p2p/discoveryv5/[enr, node, protocol],

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -21,7 +21,6 @@ import
   ../protocol/waku_lightpush/waku_lightpush,
   ../protocol/waku_rln_relay/[waku_rln_relay_types], 
   ../utils/[peers, requests, wakuswitch, wakuenr],
-  ./storage/migration/migration_types,
   ./peer_manager/peer_manager,
   ./dnsdisc/waku_dnsdisc,
   ./discv5/waku_discv5,

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -7,7 +7,7 @@
 # Group by std, external then internal imports
 import
   # std imports
-  std/[tables, times, sequtils, algorithm, options, math],
+  std/[tables, times, sequtils, options, math],
   # external imports
   bearssl,
   chronicles,

--- a/waku/v2/utils/wakuswitch.nim
+++ b/waku/v2/utils/wakuswitch.nim
@@ -1,13 +1,11 @@
 # Waku Switch utils.
 {.push raises: [TLSStreamProtocolError, IOError, Defect].}
 import
-  std/[options, sequtils, strutils],
+  std/options,
   chronos, chronicles,
-  stew/byteutils,
   eth/keys,
   libp2p/crypto/crypto,
   libp2p/protocols/pubsub/gossipsub,
-  libp2p/nameresolving/dnsresolver,
   libp2p/nameresolving/nameresolver,
   libp2p/builders,
   libp2p/transports/[transport, tcptransport, wstransport]


### PR DESCRIPTION
Remove multiple `UnusedImport` warnings from the codebase:

```bash
/home/lorenzo/code/status/nwaku/waku/v2/protocol/waku_store/waku_store.nim(10, 6) Warning: imported and not used: 'algorithm' [UnusedImport]
/home/lorenzo/code/status/nwaku/waku/v2/utils/wakuswitch.nim(6, 7) Warning: imported and not used: 'byteutils' [UnusedImport]
/home/lorenzo/code/status/nwaku/waku/v2/utils/wakuswitch.nim(4, 6) Warning: imported and not used: 'sequtils' [UnusedImport]
/home/lorenzo/code/status/nwaku/waku/v2/utils/wakuswitch.nim(10, 23) Warning: imported and not used: 'dnsresolver' [UnusedImport]
/home/lorenzo/code/status/nwaku/waku/v2/node/config.nim(11, 3) Warning: imported and not used: 'web3' [UnusedImport]
/home/lorenzo/code/status/nwaku/waku/v2/node/discv5/waku_discv5.nim(4, 6) Warning: imported and not used: 'sequtils' [UnusedImport]
/home/lorenzo/code/status/nwaku/tests/v2/test_wakunode.nim(27, 3) Warning: imported and not used: 'test_helpers' [UnusedImport]
/home/lorenzo/code/status/nwaku/tests/v2/test_wakunode.nim(5, 6) Warning: imported and not used: 'sequtils' [UnusedImport]
/home/lorenzo/code/status/nwaku/tests/v2/test_waku_pagination.nim(3, 6) Warning: imported and not used: 'algorithm' [UnusedImport]
/home/lorenzo/code/status/nwaku/tests/v2/test_waku_pagination.nim(8, 3) Warning: imported and not used: 'test_helpers' [UnusedImport]
/home/lorenzo/code/status/nwaku/tests/v2/test_waku_payload.nim(7, 3) Warning: imported and not used: 'test_helpers' [UnusedImport]
/home/lorenzo/code/status/nwaku/tests/v2/test_jsonrpc_waku.nim(29, 3) Warning: imported and not used: 'test_helpers' [UnusedImport]
/home/lorenzo/code/status/nwaku/tests/v2/test_migration_utils.nim(4, 6) Warning: imported and not used: 'sequtils' [UnusedImport]
/home/lorenzo/code/status/nwaku/tests/v2/test_waku_discv5.nim(4, 6) Warning: imported and not used: 'sequtils' [UnusedImport]
```