### PR TITLE
fix(dnsclient): update dnsclient.nim submodule with TXT record fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -137,9 +137,9 @@
 	branch = main
 [submodule "vendor/dnsclient.nim"]
 	path = vendor/dnsclient.nim
-	url = https://github.com/ba0f3/dnsclient.nim.git
+	url = https://github.com/jm-clius/dnsclient.nim.git
 	ignore = untracked
-	branch = master
+	branch = fix/txt-strings
 [submodule "vendor/nim-toml-serialization"]
 	path = vendor/nim-toml-serialization
 	url = https://github.com/status-im/nim-toml-serialization.git


### PR DESCRIPTION
A bug in a submodule ([ba0f3/dnsclient.nim](https://github.com/ba0f3/dnsclient.nim)) causes DNS TXT record parsing to fail for records consisting of multiple strings. Long TXT records are split into multiple strings by most domain providers if they become longer than the maximum length per string (255 chars).

## Impact on us:

- DNS discovery fails on existing fleets, as encoded node ENRs are longer than 255 chars and therefore split into multiple strings per record. In fact, a fatal exception causes the `wakunode2` to terminate.
- Applications relying on DNS discovery, such as `chat2`, fail to connect to any fleet and terminate with an unhandled exception. (cc @staheri14 who reported the `chat2` failures)
- Nodes relying on DNS discovery to bootstrap their discv5 DHTs fail to do so.

## Fix:

I've opened [a fix in the submodule](https://github.com/ba0f3/dnsclient.nim/pull/11) for review. Until that gets merged, I've pointed the submodule to my fork and fix branch.