### PR TITLE
Use Zerokit RLN module in nwaku

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -151,4 +151,4 @@
 [submodule "vendor/zerokit"]
 	path = vendor/zerokit
 	url = https://github.com/vacp2p/zerokit.git
-	branch = update-api
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -148,3 +148,7 @@
 	url = https://github.com/status-im/nim-presto.git
 	ignore = untracked
 	branch = master
+[submodule "vendor/zerokit"]
+	path = vendor/zerokit
+	url = https://github.com/vacp2p/zerokit.git
+	branch = update-api

--- a/Makefile
+++ b/Makefile
@@ -168,9 +168,9 @@ endif
 
 rlnlib:
 ifeq ($(RLN), true)
-	cargo build --manifest-path vendor/rln/Cargo.toml
+	cargo build --manifest-path vendor/zerokit/rln/Cargo.toml
 else  ifeq ($(CI), true)
-	cargo build --manifest-path vendor/rln/Cargo.toml
+	cargo build --manifest-path vendor/zerokit/rln/Cargo.toml
 endif
 
 test2: | build deps installganache
@@ -227,11 +227,11 @@ clean: | clean-common
 ifneq ($(USE_LIBBACKTRACE), 0)
 	+ $(MAKE) -C vendor/nim-libbacktrace clean $(HANDLE_OUTPUT)
 endif
-	cargo clean --manifest-path vendor/rln/Cargo.toml
+	cargo clean --manifest-path vendor/zerokit/rln/Cargo.toml
 
 # clean the rln build (forces recompile of old crates on next build)
 cleanrln:
-	cargo clean --manifest-path vendor/rln/Cargo.toml
+	cargo clean --manifest-path vendor/zerokit/rln/Cargo.toml
 
 endif # "variables.mk" was not included
 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -358,7 +358,7 @@ suite "Waku rln relay":
       hashSuccess
     let outputArr = cast[ptr array[32, byte]](outputBuffer.`ptr`)[]
     check:
-      "efb8ac39dc22eaf377fe85b405b99ba78dbc2f3f32494add4501741df946bd1d" ==
+      "4c6ea217404bd5f10e243bac29dc4f1ec36bf4a41caba7b4c8075c54abb3321e" ==
           outputArr.toHex()
 
     var
@@ -379,7 +379,7 @@ suite "Waku rln relay":
 
     let hash = rln.hash(msg)
     check:
-      "efb8ac39dc22eaf377fe85b405b99ba78dbc2f3f32494add4501741df946bd1d" ==
+      "4c6ea217404bd5f10e243bac29dc4f1ec36bf4a41caba7b4c8075c54abb3321e" ==
           hash.toHex()
 
   test "create a list of membership keys and construct a Merkle tree based on the list":

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -790,9 +790,9 @@ procSuite "WakuNode":
       await node1.publish(rlnRelayPubSubTopic, message)
       await sleepAsync(2000.millis)
 
-
+      ## Current circom takes more time to load the circuit..
       check:
-        (await completionFut.withTimeout(10.seconds)) == true
+        (await completionFut.withTimeout(200.seconds)) == true
 
       await node1.stop()
       await node2.stop()
@@ -893,9 +893,10 @@ procSuite "WakuNode":
       await node1.publish(rlnRelayPubSubTopic, message)
       await sleepAsync(2000.millis)
 
+      ## Current circom takes more time to load the circuit...
       check:
         # the relayHandler of node3 never gets called
-        (await completionFut.withTimeout(10.seconds)) == false
+        (await completionFut.withTimeout(200.seconds)) == false
 
       await node1.stop()
       await node2.stop()

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -318,7 +318,7 @@ const
   # STATIC_GROUP_MERKLE_ROOT is the root of the Merkle tree constructed from the STATIC_GROUP_KEYS above
   # only identity commitments are used for the Merkle tree construction
   # the root is created locally, using createMembershipList proc from waku_rln_relay_utils module, and the result is hardcoded in here
-  STATIC_GROUP_MERKLE_ROOT* = "a1877a553eff12e1b21632a0545a916a5c5b8060ad7cc6c69956741134397b2d"
+  STATIC_GROUP_MERKLE_ROOT* = "2af1e8ca39f5b1c3b097d37c2281da47b5a9b5cdde0525fe51dd929c27cb5400"
 
 const EPOCH_UNIT_SECONDS* = float64(10) # the rln-relay epoch length in seconds
 const MAX_CLOCK_GAP_SECONDS* = 20.0 # the maximum clock difference between peers in seconds

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -9,8 +9,7 @@ import
   stew/arrayops,
   ../../utils/protobuf
 
-## Bn256 and RLN are Nim wrappers for the data types used in
-#type RLN* = pointer
+## RLN is a Nim wrapper for the data types used in zerokit RLN
 type RLN* {.incompleteStruct.} = object
 
 type
@@ -18,7 +17,6 @@ type
   IDKey* = array[32, byte]
   # hash of identity key as defined ed in https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Membership
   IDCommitment* = array[32, byte]
-
 
 type
   MerkleNode* = array[32, byte] # Each node of the Merkle tee is a Poseidon hash which is a 32 byte value


### PR DESCRIPTION
This PR replaces [Kilic's RLN](https://github.com/kilic/rln) implementation with [Zerokit RLN](https://github.com/vacp2p/zerokit) module in nwaku.

Minor changes to the nim wrappers were required, as well us update of constants in tests.