### PR TITLE
Prerequistes for RLN integration tutorial

### DIFF
--- a/docs/tutorial/Pre-requisites of running a Waku node.md
+++ b/docs/tutorial/Pre-requisites of running a Waku node.md
@@ -1,0 +1,116 @@
+---
+title: 'Pre-requisites of running a Waku node'
+---
+
+Pre-requisites of running a Waku node
+===
+
+## Table of Contents
+
+[TOC]
+
+## Creating Goerli Ethereum Account and obtaining its private key
+
+
+1. Download and install Metamask [https://metamask.io/download/](https://metamask.io/download/)
+2. Create a new wallet and save your secret recovery key
+    
+    ![](https://i.imgur.com/HEOI0kp.jpg)
+
+3. Login to Metamask
+    
+    ![](https://i.imgur.com/zFduIV8.jpg)
+
+4. You should already see an account created. As you can see on top right, it should be pointing to Ethereum mainnet.
+    
+    ![](https://i.imgur.com/gk3TWUd.jpg)
+
+5. You can use the same account for different networks.
+6. You can switch to a test network by clicking on the drop down menu like so:
+
+    ![](https://i.imgur.com/kbuup6y.jpg)
+
+7. Click on Show/hide test networks
+8. Enable “Show Test Networks
+    
+    ![](https://i.imgur.com/ztiyKsB.jpg)
+    
+    ![](https://i.imgur.com/UFsoRHR.jpg)
+
+9. Close the settings and now you should see the test networks in the drop down on the top right
+    
+    ![](https://i.imgur.com/leSYt4z.jpg)
+
+10. Switch to Goerli Test Network
+11. You can see that the same account can be used with different networks. But note that the ETH balance on different networks are different and are different tokens.
+    
+    ![](https://i.imgur.com/Y7YkuEe.jpg)
+
+12. Now to export your private key for the account, if needed, please click on the three dots beside the account.
+    
+    ![](https://i.imgur.com/GjwoDPE.jpg)
+
+13. Click on Account Details
+14. Click on Export Private Key
+    
+    ![](https://i.imgur.com/7g6SyuX.jpg)
+
+15. Enter your Metamask password when prompted
+    
+    ![](https://i.imgur.com/VOojHY5.jpg)
+
+16. You will be shown the private key. Copy it as needed.
+
+Obtain Goerli Ethers from faucet
+---
+
+1. Ethers on Goerli test networks can be obtained from different faucets
+2. Some of the faucets are as follows
+    1. [https://goerlifaucet.com/](https://goerlifaucet.com/)
+    2. [https://goerli-faucet.slock.it/](https://goerli-faucet.slock.it/)
+    3. [https://goerli-faucet.pk910.de/](https://goerli-faucet.pk910.de/)
+3. Please follow the instructions on the webpages of these faucets
+4. A lot of faucets limit the Goerli ETH to 0.05 ETH/day
+5. To obtain more eth, you can do some POW mining. One of those POW faucet is
+     [https://goerli-faucet.pk910.de/](https://goerli-faucet.pk910.de/)
+6. Enter your Eth account address, accept Captcha and start mining
+    
+    ![](https://i.imgur.com/TCy2BQv.jpg)
+
+
+7. You can see the estimated Goerli ETH mined per hour. Each session is restricted to a few hours.
+    
+    ![](https://i.imgur.com/qTWwyNr.jpg)
+
+8. When you exceed the hour limit of the session, then the mining will be stopped
+9. Alternatively, stop the mining when mined enough goerli ether.
+10. Do not forget to claim your goerli ether.
+    
+    ![](https://i.imgur.com/1s7qQU8.jpg)
+    
+    
+Setting up a hosted node on Goerli Testnet using Infura
+---
+
+1. Sign up to infura if you do not have an account already. [https://infura.io/register](https://infura.io/register)
+    
+    ![](https://i.imgur.com/SyLaG6s.jpg)
+
+2. After registering and verifying the account, create a new project using Ethereum and give it a name
+    
+    ![](https://i.imgur.com/fJbNqwd.jpg)
+
+3. After creating the project, you will be presented with a dashboard like follows. Note that your Project Id and secret will be different.
+    
+    ![](https://i.imgur.com/PfGmq4i.jpg)
+
+4. Select Gorli network in Endpoints
+    
+    ![](https://i.imgur.com/93Sk8cK.jpg)
+
+5. You can find the endpoints for the hosted node using https and wss. Like follows:
+    
+    ![](https://i.imgur.com/NEuHBE7.jpg)
+
+6. You can change security settings or view usage options as required in the dashboard
+7. Congratulations, you are now ready to use the Infura node


### PR DESCRIPTION
These are the tutorials on the pre-requisites needed to integrate the RLN contract with nWaku.

- Creating Goerli Ethereum Account and obtaining its private key
- Obtain Goerli Ethers from faucet
- Setting up a hosted node on Goerli Testnet using Infura