### PR TITLE
ci: disable Nim compiler colors

### DIFF
--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -7,7 +7,12 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Flags for Nim compilation.',
-      defaultValue: params.NIMFLAGS ?: '-d:disableMarchNative -d:insecure --parallelBuild:6'
+      defaultValue: params.NIMFLAGS ?: [
+        '--colors:off',
+        '-d:insecure',
+        '-d:disableMarchNative',
+        '--parallelBuild:6',
+      ].join(' ')
     )
     string(
       name: 'LOG_LEVEL',

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -33,7 +33,12 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Flags for Nim compilation.',
-      defaultValue: params.NIMFLAGS ?: '-d:disableMarchNative -d:chronicles_colors:none -d:insecure',
+      defaultValue: params.NIMFLAGS ?: [
+        '--colors:off',
+        '-d:disableMarchNative',
+        '-d:chronicles_colors:none',
+        '-d:insecure',
+      ].join(' ')
     )
   }
 


### PR DESCRIPTION
Because they make things unreadable:
```
13:31:27  [0m[91m [0m[91m [0m[91mDownloaded[0m[91m [0m[91msubtle v1.0.0[0m[91m
13:31:27  [0m[91m [0m[91m [0m[91mDownloaded[0m[91m [0m[91marrayvec v0.4.12[0m[91m
13:31:27  [0m[91m [0m[91m [0m[91mDownloaded[0m[91m [0m[91mnodrop v0.1.14[0m[91m
```