### PR TITLE
refactor(waku-store): reorganise pagination test cases

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -5,9 +5,10 @@ import
   ./v2/test_wakunode,
   ./v2/test_waku_store,
   ./v2/test_waku_filter,
-  ./v2/test_waku_pagination,
   ./v2/test_waku_payload,
   ./v2/test_waku_swap,
+  ./v2/test_utils_pagination,
+  ./v2/test_message_store_queue_pagination,
   ./v2/test_message_store,
   ./v2/test_jsonrpc_waku,
   ./v2/test_rest_serdes,
@@ -27,7 +28,6 @@ import
   ./v2/test_waku_discv5,
   ./v2/test_enr_utils,
   ./v2/test_waku_store_queue,
-  ./v2/test_pagination_utils,
   ./v2/test_peer_exchange,
   ./v2/test_waku_noise
 

--- a/tests/v2/test_waku_payload.nim
+++ b/tests/v2/test_waku_payload.nim
@@ -3,7 +3,8 @@
 import
   testutils/unittests,
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/node/waku_payload
+  ../../waku/v2/node/waku_payload,
+  ../../waku/v2/utils/time
 
 procSuite "Waku Payload":
   let rng = newRng()
@@ -109,3 +110,46 @@ procSuite "Waku Payload":
 
     check:
       decoded.isErr()
+
+  test "Encode/Decode waku message with timestamp":
+    ## Test encoding and decoding of the timestamp field of a WakuMessage
+
+    ## Given
+    let
+      version = 0'u32
+      payload = @[byte 0, 1, 2]
+      timestamp = Timestamp(10)
+      msg = WakuMessage(payload: payload, version: version, timestamp: timestamp)
+      
+    ## When
+    let pb =  msg.encode()
+    let msgDecoded = WakuMessage.init(pb.buffer)
+    
+    ## Then
+    check:
+      msgDecoded.isOk()
+    
+    let timestampDecoded = msgDecoded.value.timestamp
+    check:
+      timestampDecoded == timestamp
+
+  test "Encode/Decode waku message without timestamp":
+    ## Test the encoding and decoding of a WakuMessage with an empty timestamp field  
+
+    ## Given
+    let
+      version = 0'u32
+      payload = @[byte 0, 1, 2]
+      msg = WakuMessage(payload: payload, version: version)
+    
+    ## When
+    let pb =  msg.encode()
+    let msgDecoded = WakuMessage.init(pb.buffer)
+
+    ## Then
+    check:
+      msgDecoded.isOk()
+    
+    let timestampDecoded = msgDecoded.value.timestamp
+    check:
+      timestampDecoded == Timestamp(0)


### PR DESCRIPTION
There is some test suite grooming work pending after the previous big PR merged. This is one PR related to that:
* Move the payload-related test cases under the right test suite
* Move the message store test cases (StoreQueue) under its own test suite file
* Group the pagination utils test cases under the same test suite
