### PR TITLE
refactor(waku-store): inherit from message_store in store_queue

### DIFF
--- a/waku/v2/node/storage/message/message_store.nim
+++ b/waku/v2/node/storage/message/message_store.nim
@@ -6,18 +6,33 @@
 import
   std/options,
   stew/results,
+  chronos
+import
   ../../../protocol/waku_message,
   ../../../protocol/waku_store/rpc,
   ../../../utils/time,
   ../../../utils/pagination
 
 
-type
-  DataProc* = proc(receiverTimestamp: Timestamp, msg: WakuMessage, pubsubTopic: string) {.closure, raises: [Defect].}
+const 
+  StoreDefaultCapacity* = 25_000
+  StoreMaxOverflow* = 1.3
+  StoreDefaultRetentionTime* = chronos.days(30).seconds
+  StoreMaxPageSize* = 100.uint64
+  StoreMaxTimeVariance* = getNanoSecondTime(20) # 20 seconds maximum allowable sender timestamp "drift" into the future
 
+
+type
   MessageStoreResult*[T] = Result[T, string]
+  
+  MessageStorePage* = (seq[WakuMessage], Option[PagingInfo])
+
+  MessageStoreRow* = (Timestamp, WakuMessage, string)
 
   MessageStore* = ref object of RootObj
+
+# TODO: Deprecate the following type
+type DataProc* = proc(receiverTimestamp: Timestamp, msg: WakuMessage, pubsubTopic: string) {.closure, raises: [Defect].}
 
 
 # TODO: Remove after resolving nwaku #1026. Move it back to waku_store_queue.nim
@@ -33,8 +48,29 @@ type
 
 
 # MessageStore interface
+method getMostRecentMessageTimestamp*(db: MessageStore): MessageStoreResult[Timestamp] {.base.} = discard
+
+method getOldestMessageTimestamp*(db: MessageStore): MessageStoreResult[Timestamp] {.base.} = discard
+
 method put*(db: MessageStore, cursor: Index, message: WakuMessage, pubsubTopic: string): MessageStoreResult[void] {.base.} = discard
+
+
+# TODO: Deprecate the following methods after after #1026
 method getAll*(db: MessageStore, onData: DataProc): MessageStoreResult[bool] {.base.} = discard
 method getPage*(db: MessageStore, pred: QueryFilterMatcher, pagingInfo: PagingInfo): MessageStoreResult[(seq[WakuMessage], PagingInfo, HistoryResponseError)] {.base.} = discard
 method getPage*(db: MessageStore, pagingInfo: PagingInfo): MessageStoreResult[(seq[WakuMessage], PagingInfo, HistoryResponseError)] {.base.} = discard
 
+
+# TODO: Move to sqlite store
+method getAllMessages(db: MessageStore): MessageStoreResult[seq[MessageStoreRow]] {.base.} = discard
+
+method getMessagesByHistoryQuery*(
+  db: MessageStore,
+  contentTopic = none(seq[ContentTopic]),
+  pubsubTopic = none(string),
+  cursor = none(Index),
+  startTime = none(Timestamp),
+  endTime = none(Timestamp),
+  maxPageSize = StoreMaxPageSize,
+  ascendingOrder = true
+): MessageStoreResult[MessageStorePage] {.base.} = discard


### PR DESCRIPTION
There is some test suite grooming work pending after the previous big PR merged. This is another PR related to that:

* Inherit from MessageStore in StoreQueue (a.k.a. in-memory store) implementation
* Unify the message store interface (add new methods that will replace the existing ones in the upcoming PRs)

This is work to accommodate the changes necessary for https://github.com/status-im/nwaku/issues/1026