### PR TITLE
refactor(waku-lightpush): remove wakunode2 waku_lightpush exports

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -21,9 +21,11 @@ import libp2p/[switch,                   # manage transports, a single entry poi
                protocols/secure/secio,   # define the protocol of secure input / output, allows encrypted communication that uses public keys to validate signed messages instead of a certificate authority like in TLS
                nameresolving/dnsresolver,# define DNS resolution
                muxers/muxer]             # define an interface for stream multiplexing, allowing peers to offer many protocols over a single connection
-import   ../../waku/v2/node/[wakunode2, waku_payload],
-         ../../waku/v2/node/dnsdisc/waku_dnsdisc,
+import   ../../waku/v2/protocol/waku_message,
+         ../../waku/v2/protocol/waku_lightpush,
          ../../waku/v2/protocol/waku_store,
+         ../../waku/v2/node/[wakunode2, waku_payload],
+         ../../waku/v2/node/dnsdisc/waku_dnsdisc,
          ../../waku/v2/utils/[peers,time],
          ../../waku/common/utils/nat,
          ./config_chat2

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -35,7 +35,6 @@ export
   waku_store,
   waku_swap,
   waku_filter,
-  waku_lightpush,
   waku_rln_relay_types,
   wakunode2_types
 


### PR DESCRIPTION
To continue the lightpush protocol code reorganization and module/imports untangling work:

* Remove the `waku_lightpush` export from `wakunode2.nim` to avoid future cyclic import issues
* Update all the imports of wakunode2 accordingly

This is a cleanup/code reorganization PR.
