### PR TITLE
refactor(waku-store): remove wakunode2 waku_store exports

### DIFF
--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -11,10 +11,12 @@ import
   libp2p/stream/[bufferstream, connection],
   libp2p/crypto/crypto,
   libp2p/protocols/pubsub/pubsub,
-  libp2p/protocols/pubsub/rpc/message,
-  ../../waku/v2/node/wakunode2,
+  libp2p/protocols/pubsub/rpc/message
+import
+  ../../waku/v2/protocol/waku_store,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/storage/peer/waku_peer_storage,
+  ../../waku/v2/node/wakunode2,
   ../test_helpers
 
 procSuite "Peer Manager":

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -4,9 +4,11 @@ import
   std/[options, sequtils, sets],
   chronicles,
   json_rpc/rpcserver,
-  libp2p/[peerinfo, switch],
-  ../wakunode2,
+  libp2p/[peerinfo, switch]
+import
+  ../../protocol/waku_store,
   ../peer_manager/peer_manager,
+  ../wakunode2,
   ./jsonrpc_types
 
 export jsonrpc_types

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -32,7 +32,6 @@ import
 export
   builders,
   waku_relay, waku_message,
-  waku_store,
   waku_swap,
   waku_filter,
   waku_rln_relay_types,


### PR DESCRIPTION
To continue the store protocol code reorganization and module/imports untangling work:

* Remove the `waku_store` export from `wakunode2.nim` to avoid future cyclic import issues
* Update all the imports of wakunode2 accordingly

This is a cleanup/code reorganization PR.