### PR TITLE
fix: do not attempt connecting to empty dynamic bootstrap node list

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -1071,8 +1071,9 @@ when isMainModule:
     if conf.staticnodes.len > 0:
       waitFor connectToNodes(node, conf.staticnodes, "static")
     
-    info "Connecting to dynamic bootstrap peers"
-    waitFor connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")
+    if dynamicBootstrapNodes.len > 0:
+      info "Connecting to dynamic bootstrap peers"
+      waitFor connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")
     
     # Start keepalive, if enabled
     if conf.keepAlive:


### PR DESCRIPTION
Closes https://github.com/status-im/nwaku/issues/1086

This simple fix avoids unnecessary waiting for `connectToNodes` if no dynamic bootstrap nodes are found during the setup process.