### PR TITLE
refactor(waku-filter): remove wakunode2 waku_filter exports

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -23,10 +23,11 @@ import libp2p/[switch,                   # manage transports, a single entry poi
                muxers/muxer]             # define an interface for stream multiplexing, allowing peers to offer many protocols over a single connection
 import   ../../waku/v2/protocol/waku_message,
          ../../waku/v2/protocol/waku_lightpush,
+         ../../waku/v2/protocol/waku_filter, 
          ../../waku/v2/protocol/waku_store,
          ../../waku/v2/node/[wakunode2, waku_payload],
          ../../waku/v2/node/dnsdisc/waku_dnsdisc,
-         ../../waku/v2/utils/[peers,time],
+         ../../waku/v2/utils/[peers, time],
          ../../waku/common/utils/nat,
          ./config_chat2
 

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -13,7 +13,9 @@ import
   libp2p/protocols/pubsub/pubsub,
   libp2p/protocols/pubsub/rpc/message
 import
+  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store,
+  ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/storage/peer/waku_peer_storage,
   ../../waku/v2/node/wakunode2,

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -6,7 +6,9 @@ import
   json_rpc/rpcserver,
   libp2p/[peerinfo, switch]
 import
+  ../../protocol/waku_message,
   ../../protocol/waku_store,
+  ../../protocol/waku_filter,
   ../peer_manager/peer_manager,
   ../wakunode2,
   ./jsonrpc_types

--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -3,7 +3,10 @@
 import
   std/[tables,sequtils],
   chronicles,
-  json_rpc/rpcserver,
+  json_rpc/rpcserver
+import
+  ../../protocol/waku_message,
+  ../../protocol/waku_filter,
   ../wakunode2,
   ./jsonrpc_types
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -33,7 +33,6 @@ export
   builders,
   waku_relay, waku_message,
   waku_swap,
-  waku_filter,
   waku_rln_relay_types,
   wakunode2_types
 


### PR DESCRIPTION
To continue the store protocol code reorganization and module/imports untangling work:

* Remove the `waku_filter` export from `wakunode2.nim` to avoid future cyclic import issues
* Update all the imports of wakunode2 accordingly

This is a cleanup/code reorganization PR.