### PR TITLE
Periodic logging for additional metrics

### DIFF
--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -324,7 +324,7 @@ type
 
     metricsLogging* {.
       desc: "Enable metrics logging: true|false"
-      defaultValue: false
+      defaultValue: true
       name: "metrics-logging" }: bool
     
     ## DNS discovery config

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -9,7 +9,9 @@ import
   metrics/chronos_httpserver,
   ./config,
   ./wakunode2,
-  ../protocol/waku_filter
+  ../protocol/waku_filter,
+  ../protocol/waku_store,
+  ../protocol/waku_lightpush
 
 logScope:
   topics = "wakunode.setup.metrics"
@@ -56,11 +58,13 @@ proc startMetricsLog*() =
       cumulativeErrors = totalErrors
       cumulativeConns = totalConnections
       info "Total connections initiated", count = freshConnCount
-      info "Total Messages", count = parseCollectorIntoF64(waku_node_messages)
-      info "Total SWAP peers", count = parseCollectorIntoF64(waku_swap_peers_count)
-      info "Total FILTER peers", count = parseCollectorIntoF64(waku_filter_peers)
+      info "Total messages", count = parseCollectorIntoF64(waku_node_messages)
+      info "Total swap peers", count = parseCollectorIntoF64(waku_swap_peers_count)
+      info "Total filter peers", count = parseCollectorIntoF64(waku_filter_peers)
+      info "Total store peers", count = parseCollectorIntoF64(waku_store_peers)
+      info "Total lightpush peers", count = parseCollectorIntoF64(waku_lightpush_peers)
       info "Total errors", count = freshErrorCount
-      info "Total subscribed topics", count = parseCollectorIntoF64(waku_filter_subscribers)
+      info "Total active filter subscriptions", count = parseCollectorIntoF64(waku_filter_subscribers)
 
     discard setTimer(Moment.fromNow(30.seconds), logMetrics)
   

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -8,7 +8,8 @@ import
   metrics,
   metrics/chronos_httpserver,
   ./config,
-  ./wakunode2
+  ./wakunode2,
+  ../protocol/waku_filter
 
 logScope:
   topics = "wakunode.setup.metrics"

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -45,12 +45,12 @@ proc startMetricsLog*() =
       # TODO: libp2p_pubsub_peers is not public, so we need to make this either
       # public in libp2p or do our own peer counting after all.
 
-      var totalErrors = parseCollectorIntoF64(waku_node_errors)
-      var totalConnections = parseCollectorIntoF64(waku_node_conns_initiated)
+      let totalErrors = parseCollectorIntoF64(waku_node_errors)
+      let totalConnections = parseCollectorIntoF64(waku_node_conns_initiated)
 
       # track cumulative, and then max.
-      var freshErrorCount = max(totalErrors - cumulativeErrors, 0)
-      var freshConnCount = max(totalConnections - cumulativeConns, 0)
+      let freshErrorCount = max(totalErrors - cumulativeErrors, 0)
+      let freshConnCount = max(totalConnections - cumulativeConns, 0)
       
       cumulativeErrors = totalErrors
       cumulativeConns = totalConnections

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -24,24 +24,44 @@ proc startMetricsServer*(serverIp: ValidIpAddress, serverPort: Port) =
 
     info "Metrics HTTP server started", serverIp, serverPort
 
+proc parseCollectorIntoF64(collector: Collector): float64 = 
+  var total = 0.float64
+  for key in collector.metrics.keys():
+    try:
+      total = total + collector.value(key)
+    except KeyError:
+      discard
+  return total
 
 proc startMetricsLog*() =
   # https://github.com/nim-lang/Nim/issues/17369
   var logMetrics: proc(udata: pointer) {.gcsafe, raises: [Defect].}
 
+  var cumulativeErrors = 0.float64
+  var cumulativeConns = 0.float64
+
   logMetrics = proc(udata: pointer) =
     {.gcsafe.}:
       # TODO: libp2p_pubsub_peers is not public, so we need to make this either
       # public in libp2p or do our own peer counting after all.
-      var totalMessages = 0.float64
-      for key in waku_node_messages.metrics.keys():
-        try:
-          totalMessages = totalMessages + waku_node_messages.value(key)
-        except KeyError:
-          discard
 
-    info "Node metrics", totalMessages
-    discard setTimer(Moment.fromNow(2.seconds), logMetrics)
+      var totalErrors = parseCollectorIntoF64(waku_node_errors)
+      var totalConnections = parseCollectorIntoF64(waku_node_conns_initiated)
+
+      # track cumulative, and then max.
+      var freshErrorCount = max(totalErrors - cumulativeErrors, 0)
+      var freshConnCount = max(totalConnections - cumulativeConns, 0)
+      
+      cumulativeErrors = totalErrors
+      cumulativeConns = totalConnections
+      info "Total connections initiated", count = freshConnCount
+      info "Total Messages", count = parseCollectorIntoF64(waku_node_messages)
+      info "Total SWAP peers", count = parseCollectorIntoF64(waku_swap_peers_count)
+      info "Total FILTER peers", count = parseCollectorIntoF64(waku_filter_peers)
+      info "Total errors", count = freshErrorCount
+      info "Total subscribed topics", count = parseCollectorIntoF64(waku_filter_subscribers)
+
+    discard setTimer(Moment.fromNow(30.seconds), logMetrics)
   
-  discard setTimer(Moment.fromNow(2.seconds), logMetrics)
+  discard setTimer(Moment.fromNow(30.seconds), logMetrics)
   


### PR DESCRIPTION
Should resolve #984


- chore: enable metrics logging by default
- feat(logging): add additional logging metrics, change period to 30 seconds

We now log the following fields:
- Total connections initiated (peer count) since last log
- Total Messages
- Total SWAP peers
- Total FILTER peers
- Total errors since last log
- Total subscribed topics

Should the docs mention which fields refer to values over the last reporting period vs since the node setup?


