### PR TITLE
fix(rest): encode waku message payload in base64

### DIFF
--- a/tests/v2/test_rest_relay_api.nim
+++ b/tests/v2/test_rest_relay_api.nim
@@ -11,7 +11,7 @@ import
   libp2p/protocols/pubsub/pubsub
 import
   ../../waku/v2/node/wakunode2,
-  ../../waku/v2/node/rest/[server, client, utils],
+  ../../waku/v2/node/rest/[server, client, base64, utils],
   ../../waku/v2/node/rest/relay/[api_types, relay_api, topic_cache]
 
 
@@ -164,8 +164,8 @@ suite "REST API - Relay":
       response.contentType == $MIMETYPE_JSON
       response.data.len == 3
       response.data.all do (msg: RelayWakuMessage) -> bool: 
-        msg.payload == "TEST-1" and
-        string(msg.contentTopic.get()) == "content-topic-x" and
+        msg.payload == Base64String.encode("TEST-1") and
+        msg.contentTopic.get().string == "content-topic-x" and
         msg.version.get() == Natural(1) and
         msg.timestamp.get() == int64(2022)
 
@@ -211,7 +211,7 @@ suite "REST API - Relay":
     discard await client.relayPostSubscriptionsV1(newTopics)
     
     let response = await client.relayPostMessagesV1(defaultTopic, RelayWakuMessage(
-      payload: "TEST-PAYLOAD", 
+      payload: Base64String.encode("TEST-PAYLOAD"), 
       contentTopic: some(ContentTopicString(defaultContentTopic)), 
       timestamp: some(int64(2022))
     ))

--- a/tests/v2/test_rest_relay_api_serdes.nim
+++ b/tests/v2/test_rest_relay_api_serdes.nim
@@ -1,12 +1,13 @@
 {.used.}
 
-import std/typetraits
-import chronicles,
-  unittest2,
+import
   stew/[results, byteutils],
+  chronicles,
+  unittest2,
   json_serialization
 import 
   ../../waku/v2/node/rest/serdes,
+  ../../waku/v2/node/rest/base64,
   ../../waku/v2/node/rest/relay/api_types
 
 
@@ -15,25 +16,27 @@ suite "Relay API - serialization":
   suite "RelayWakuMessage - decode":
     test "optional fields are not provided":
       # Given
-      let jsonBytes = toBytes("""{ "payload": "MESSAGE" }""")
+      let payload = Base64String.encode("MESSAGE")
+      let jsonBytes = toBytes("{\"payload\":\"" & $payload & "\"}")
 
       # When
       let res = decodeFromJsonBytes(RelayWakuMessage, jsonBytes, requireAllFields = true)
 
       # Then
-      require(res.isOk)
+      require(res.isOk())
       let value = res.get()
       check:
-        value.payload == "MESSAGE"
-        value.contentTopic.isNone
-        value.version.isNone
-        value.timestamp.isNone
+        value.payload == payload
+        value.contentTopic.isNone()
+        value.version.isNone()
+        value.timestamp.isNone()
 
   suite "RelayWakuMessage - encode":
     test "optional fields are none":
       # Given
+      let payload = Base64String.encode("MESSAGE")
       let data = RelayWakuMessage(
-        payload: "MESSAGE", 
+        payload: payload, 
         contentTopic: none(ContentTopicString),
         version: none(Natural),
         timestamp: none(int64)
@@ -43,7 +46,7 @@ suite "Relay API - serialization":
       let res = encodeIntoJsonBytes(data)
 
       # Then
-      require(res.isOk)
+      require(res.isOk())
       let value = res.get()
       check:
-        value == toBytes("""{"payload":"MESSAGE"}""")
+        value == toBytes("{\"payload\":\"" & $payload & "\"}")

--- a/waku/v2/node/rest/base64.nim
+++ b/waku/v2/node/rest/base64.nim
@@ -1,0 +1,27 @@
+{.push raises: [Defect].}
+
+import stew/[results, byteutils, base64]
+
+
+type Base64String* = distinct string
+
+
+proc encode*(t: type Base64String, value: string|seq[byte]): Base64String =
+  let val = block:
+    when value is string:
+      toBytes(value)
+    else:
+      value
+  Base64String(base64.encode(Base64, val))
+
+proc decode*(t: Base64String): Result[seq[byte], cstring] =
+  try:
+    ok(base64.decode(Base64, string(t)))
+  except:
+    err("failed to decode base64 string")
+
+proc `$`*(t: Base64String): string {.inline.}=
+  string(t)
+
+proc `==`*(lhs: Base64String|string, rhs: Base64String|string): bool {.inline.}=
+  string(lhs) == string(rhs)

--- a/waku/v2/node/rest/relay/relay_api.yaml
+++ b/waku/v2/node/rest/relay/relay_api.yaml
@@ -118,6 +118,7 @@ components:
       properties:
         payload:
           type: string
+          format: byte
         contentTopic:
           $ref: '#/components/schemas/ContentTopic'
         version:

--- a/waku/v2/node/rest/serdes.nim
+++ b/waku/v2/node/rest/serdes.nim
@@ -1,7 +1,7 @@
 {.push raises: [Defect].}
 
-import std/typetraits
 import 
+  std/typetraits,
   stew/results,
   chronicles,
   serialization,


### PR DESCRIPTION
During Bologna's offsite, this issue was raised by @richard-ramos.

* Now the waku message payload is specified to be base64 encoded (see: [OpenAPI types](https://swagger.io/specification/#:~:text=string-,string,base64%20encoded%20characters,-string)).
* Base64 encoding wrapper.
* Encode/decode the waku messages payload when converted into/from with the Relay REST API types.
* Updated the test cases accordingly.