### PR TITLE
feat(rest): add waku filter openapi rest api specification file

### DIFF
--- a/waku/v2/node/rest/filter/openapi.yaml
+++ b/waku/v2/node/rest/filter/openapi.yaml
@@ -1,0 +1,142 @@
+openapi: 3.0.3
+info:
+  title: Waku V2 node REST API 
+  version: 1.0.0
+  contact:
+    name: VAC Team
+    url: https://forum.vac.dev/
+tags:
+  - name: filter
+    description: Filter REST API for WakuV2 node
+
+paths:
+  /filter/v1/subscriptions:
+    post: # post_waku_v2_filter_v1_subscription
+      summary: Subscribe a node to an array of topics
+      description: Subscribe a node to an array of content topics.
+      operationId: postSubscriptions
+      tags:
+        - filter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FilterPostSubscriptionsRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+        # TODO: Review the possible errors of this endpoint
+        '400':
+          description: Bad request.
+        '5XX':
+          description: Unexpected error.
+
+    delete: # delete_waku_v2_filter_v1_subscription
+      summary: Unsubscribe a node from an array of topics
+      description: Unsubscribe a node from an array of content topics.
+      operationId: deleteSubscriptions
+      tags:
+        - filter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FilterDeleteSubscriptionsRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+        # TODO: Review the possible errors of this endpoint
+        '400':
+          description: Bad request.
+        '404':
+          description: Not found.
+        '5XX':
+          description: Unexpected error.
+
+  /filter/v1/messages/{topic}:
+    get: # get_waku_v2_filter_v1_messages
+      summary: Get the latest messages on the polled content topic
+      description: Get a list of messages that were received on a subscribed content topic after the last time this method was called.
+      operationId: getMessagesByTopic
+      tags:
+        - filter
+      parameters:
+        - in: path
+          name: topic  # Note the name is the same as in the path
+          required: true
+          schema:
+            type: string
+          description: The user ID
+      responses:
+        '200':
+          description: The latest messages on the polled topic.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FilterGetMessagesResponse'
+        # TODO: Review the possible errors of this endpoint
+        '400':
+          description: Bad request.
+        '404':
+          description: Not found.
+        '5XX':
+          description: Unexpected error.
+
+components:
+  schemas:
+    PubSubTopic:
+      type: string
+    ContentTopic:
+      type: string
+    
+    FilterWakuMessage:
+      type: object
+      properties:
+        payload:
+          type: string
+          format: byte
+        contentTopic:
+          $ref: '#/components/schemas/ContentTopic'
+        version:
+          type: number
+        timestamp:
+          type: number
+      required:
+        - payload
+
+    FilterPostSubscriptionsRequest:
+      type: object
+      properties: 
+        contentFilters:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContentTopic'
+        pubsubTopic:
+          $ref: "#/components/schemas/PubSubTopic"
+      required: 
+        -  contentFilters
+
+    FilterDeleteSubscriptionsRequest:
+      type: object
+      properties: 
+        contentFilters:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContentTopic'
+        pubsubTopic:
+          $ref: "#/components/schemas/PubSubTopic"
+      required: 
+        -  contentFilters
+    
+    FilterGetMessagesResponse:
+      type: array
+      items:
+        $ref: '#/components/schemas/FilterWakuMessage'


### PR DESCRIPTION
Implement the Waku filter Rest API for Waku node:

- [x] Rest API specification (OpenAPI)
- [ ] Rest API types and serdes (in a different PR)
- [ ] HTTP Request handlers and client (in a different PR)

This PR covers partially issue #1076