### PR TITLE
feat(message-cache): make the topic cache generic

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -9,6 +9,7 @@ import
   ./v2/test_waku_payload,
   ./v2/test_waku_swap,
   ./v2/test_utils_pagination,
+  ./v2/test_message_cache,
   ./v2/test_message_store_queue,
   ./v2/test_message_store_queue_pagination,
   ./v2/test_message_store_sqlite_query,
@@ -18,7 +19,6 @@ import
   ./v2/test_rest_debug_api_serdes,
   ./v2/test_rest_debug_api,
   ./v2/test_rest_relay_api_serdes,
-  ./v2/test_rest_relay_api_topic_cache,
   ./v2/test_rest_relay_api,
   ./v2/test_peer_manager,
   ./v2/test_web3, # TODO  remove it when rln-relay tests get finalized

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -290,7 +290,7 @@ type
       defaultValue: 8645
       name: "rest-port" }: uint16
 
-    restRelayCacheCapaciy* {.
+    restRelayCacheCapacity* {.
       desc: "Capacity of the Relay REST API message cache.",
       defaultValue: 30
       name: "rest-relay-cache-capacity" }: uint32

--- a/waku/v2/node/message_cache.nim
+++ b/waku/v2/node/message_cache.nim
@@ -1,0 +1,76 @@
+{.push raises: [Defect].}
+
+import
+  std/[tables, sequtils],
+  stew/results,
+  chronicles,
+  chronos,
+  libp2p/protocols/pubsub
+import
+  ../protocol/waku_message
+
+logScope: topics = "message_cache"
+
+const DefaultMessageCacheCapacity*: uint = 30 # Max number of messages cached per topic @TODO make this configurable
+
+
+type MessageCacheResult*[T] = Result[T, cstring]
+
+type MessageCache*[K] = ref object
+  capacity: uint
+  table: Table[K, seq[WakuMessage]]
+
+func init*[K](T: type MessageCache[K], capacity=DefaultMessageCacheCapacity): T =
+  MessageCache[K](
+    capacity: capacity,
+    table: initTable[K, seq[WakuMessage]]() 
+  )
+
+
+proc isSubscribed*[K](t: MessageCache[K], topic: K): bool =
+  t.table.hasKey(topic)
+
+proc subscribe*[K](t: MessageCache[K], topic: K) =
+  if t.isSubscribed(topic):
+    return
+  t.table[topic] = @[]
+
+proc unsubscribe*[K](t: MessageCache[K], topic: K) = 
+  if not t.isSubscribed(topic):
+    return
+  t.table.del(topic)
+
+
+proc addMessage*[K](t: MessageCache, topic: K, msg: WakuMessage) =
+  if not t.isSubscribed(topic):
+    return
+
+  # Make a copy of msgs for this topic to modify
+  var messages = t.table.getOrDefault(topic, @[])
+
+  if messages.len >= t.capacity.int:
+    debug "Topic cache capacity reached", topic=topic
+    # Message cache on this topic exceeds maximum. Delete oldest.
+    # TODO: this may become a bottle neck if called as the norm rather than 
+    #  exception when adding messages. Performance profile needed.
+    messages.delete(0,0)
+  
+  messages.add(msg)
+
+  # Replace indexed entry with copy
+  t.table[topic] = messages
+
+proc clearMessages*[K](t: MessageCache[K], topic: K) =
+  if not t.isSubscribed(topic):
+    return
+  t.table[topic] = @[]
+
+proc getMessages*[K](t: MessageCache[K], topic: K, clear=false): MessageCacheResult[seq[WakuMessage]] =
+  if not t.isSubscribed(topic):
+    return err("Not subscribed to topic")
+
+  let messages = t.table.getOrDefault(topic, @[])
+  if clear:
+    t.clearMessages(topic)
+
+  ok(messages)

--- a/waku/v2/node/rest/relay/topic_cache.nim
+++ b/waku/v2/node/rest/relay/topic_cache.nim
@@ -1,98 +1,35 @@
 {.push raises: [Defect].}
 
 import
-  std/[tables, sequtils],
   stew/results,
   chronicles,
   chronos,
   libp2p/protocols/pubsub
 import
-  ../../../protocol/waku_message
+  ../../../protocol/waku_message,
+  ../../message_cache
 
 logScope: topics = "rest_api_relay_topiccache"
 
-const DEFAULT_TOPICCACHE_CAPACITY* = 30 # Max number of messages cached per topic @TODO make this configurable
+export message_cache
 
+
+##### TopicCache
 
 type PubSubTopicString = string 
 
-type TopicCacheResult*[T] = Result[T, cstring]
+type TopicCacheResult*[T] = MessageCacheResult[T]
+
+type TopicCache* = MessageCache[PubSubTopicString]
+
+
+##### Message handler
 
 type TopicCacheMessageHandler* = Topichandler
 
-
-type TopicCacheConfig* = object
-  capacity*: int
-
-proc default*(T: type TopicCacheConfig): T =
-  TopicCacheConfig(
-    capacity: DEFAULT_TOPICCACHE_CAPACITY
-  )
-
-
-type TopicCache* = ref object
-  conf: TopicCacheConfig
-  table: Table[PubSubTopicString, seq[WakuMessage]]
-
-func init*(T: type TopicCache, conf=TopicCacheConfig.default()): T =
-  TopicCache(
-    conf: conf,
-    table: initTable[PubSubTopicString, seq[WakuMessage]]() 
-  )
-
-
-proc isSubscribed*(t: TopicCache, topic: PubSubTopicString): bool =
-  t.table.hasKey(topic)
-
-proc subscribe*(t: TopicCache, topic: PubSubTopicString) =
-  if t.isSubscribed(topic):
-    return
-  t.table[topic] = @[]
-
-proc unsubscribe*(t: TopicCache, topic: PubSubTopicString) = 
-  if not t.isSubscribed(topic):
-    return
-  t.table.del(topic)
-
-
-proc addMessage*(t: TopicCache, topic: PubSubTopicString, msg: WakuMessage) =
-  if not t.isSubscribed(topic):
-    return
-
-  # Make a copy of msgs for this topic to modify
-  var messages = t.table.getOrDefault(topic, @[])
-
-  if messages.len >= t.conf.capacity:
-    debug "Topic cache capacity reached", topic=topic
-    # Message cache on this topic exceeds maximum. Delete oldest.
-    # TODO: this may become a bottle neck if called as the norm rather than 
-    #  exception when adding messages. Performance profile needed.
-    messages.delete(0,0)
-  
-  messages.add(msg)
-
-  # Replace indexed entry with copy
-  t.table[topic] = messages
-
-proc clearMessages*(t: TopicCache, topic: PubSubTopicString) =
-  if not t.isSubscribed(topic):
-    return
-  t.table[topic] = @[]
-
-proc getMessages*(t: TopicCache, topic: PubSubTopicString, clear=false): TopicCacheResult[seq[WakuMessage]] =
-  if not t.isSubscribed(topic):
-    return err("Not subscribed to topic")
-
-  let messages = t.table.getOrDefault(topic, @[])
-  if clear:
-    t.clearMessages(topic)
-
-  ok(messages)
-
-
 proc messageHandler*(cache: TopicCache): TopicCacheMessageHandler =
 
-  proc handler(topic: string, data: seq[byte]): Future[void] {.async, raises: [Defect].} =
+  let handler = proc(topic: string, data: seq[byte]): Future[void] {.async, closure.} =
     trace "Topic handler triggered", topic=topic
 
     # Add message to current cache

--- a/waku/v2/node/wakunode2_setup_rest.nim
+++ b/waku/v2/node/wakunode2_setup_rest.nim
@@ -9,8 +9,7 @@ import
   ./wakunode2,
   ./rest/server,
   ./rest/debug/debug_api,
-  ./rest/relay/[relay_api, 
-                topic_cache]
+  ./rest/relay/[relay_api, topic_cache]
 
 
 logScope:
@@ -30,9 +29,7 @@ proc startRestServer*(node: WakuNode, address: ValidIpAddress, port: Port, conf:
 
   ## Relay REST API
   if conf.relay:
-    # TODO: Simplify topic cache object initialization
-    let relayCacheConfig = TopicCacheConfig(capacity: int(conf.restRelayCacheCapaciy))
-    let relayCache = TopicCache.init(conf=relayCacheConfig)
+    let relayCache = TopicCache.init(capacity=conf.restRelayCacheCapacity)
     installRelayApiHandlers(server.router, node, relayCache)
 
   server.start()


### PR DESCRIPTION
The current topic cache implementation can be made generic to support also the filter use case. Now it allows different types of keys:

* The key type for the relay is `string` (the type of PubSub topics)
* The key type for the filter should be a tuple of `PubsubTopicString` (aka `string`) and `ContentTopic`.

This work is necessary for #1076 (filter REST API)