### PR TITLE
feat(store): Allow messages to be marked as "don't store"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,12 @@ node_modules/
 .idea/
 rlnCredentials.txt
 testPath.txt
+<<<<<<< HEAD
+
+# Nimbus Build System
+nimbus-build-system.paths
+=======
+>>>>>>> d2713745 (Revert "feat(store): replace ephemeral with ttl model")
 
 # Nimbus Build System
 nimbus-build-system.paths

--- a/.gitignore
+++ b/.gitignore
@@ -39,12 +39,6 @@ node_modules/
 .idea/
 rlnCredentials.txt
 testPath.txt
-<<<<<<< HEAD
-
-# Nimbus Build System
-nimbus-build-system.paths
-=======
->>>>>>> d2713745 (Revert "feat(store): replace ephemeral with ttl model")
 
 # Nimbus Build System
 nimbus-build-system.paths

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -32,7 +32,6 @@ proc fakeWakuMessage(
   contentTopic = DefaultContentTopic, 
   ts = getNanosecondTime(epochTime()),
   ephemeral = false,
-  storeTTL = getNanosecondTime(60*5) # 5 minutes
 ): WakuMessage = 
   WakuMessage(
     payload: toBytes(payload),
@@ -40,7 +39,6 @@ proc fakeWakuMessage(
     version: 1,
     timestamp: ts,
     ephemeral: ephemeral,
-    storeTTL: storeTTL
   )
 
 proc newTestSwitch(key=none(PrivateKey), address=none(MultiAddress)): Switch =

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -31,14 +31,16 @@ proc fakeWakuMessage(
   payload = "TEST-PAYLOAD",
   contentTopic = DefaultContentTopic, 
   ts = getNanosecondTime(epochTime()),
-  ttl = none(Timestamp),
+  ephemeral = false,
+  storeTTL = getNanosecondTime(60*5) # 5 minutes
 ): WakuMessage = 
   WakuMessage(
     payload: toBytes(payload),
     contentTopic: contentTopic,
     version: 1,
     timestamp: ts,
-    ttl: ttl,
+    ephemeral: ephemeral,
+    storeTTL: storeTTL
   )
 
 proc newTestSwitch(key=none(PrivateKey), address=none(MultiAddress)): Switch =
@@ -464,11 +466,11 @@ suite "Waku Store":
 
     ## Send 5 ephemeral messages. A message is stateful by default.
     let msgList = @[
-        fakeWakuMessage(ttl = some(Timestamp(0))),
-        fakeWakuMessage(ttl = some(Timestamp(0))),
-        fakeWakuMessage(ttl = some(Timestamp(0))),
-        fakeWakuMessage(ttl = some(Timestamp(0))),
-        fakeWakuMessage(ttl = some(Timestamp(0))),
+        fakeWakuMessage(ephemeral = true),
+        fakeWakuMessage(ephemeral = true),
+        fakeWakuMessage(ephemeral = true),
+        fakeWakuMessage(ephemeral = true),
+        fakeWakuMessage(ephemeral = true),
       ]
 
     for msg in msgList:

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -31,16 +31,14 @@ proc fakeWakuMessage(
   payload = "TEST-PAYLOAD",
   contentTopic = DefaultContentTopic, 
   ts = getNanosecondTime(epochTime()),
-  ephemeral = false,
-  storeTTL = getNanosecondTime(60*5) # 5 minutes
+  ttl = none(Timestamp),
 ): WakuMessage = 
   WakuMessage(
     payload: toBytes(payload),
     contentTopic: contentTopic,
     version: 1,
     timestamp: ts,
-    ephemeral: ephemeral,
-    storeTTL: storeTTL
+    ttl: ttl,
   )
 
 proc newTestSwitch(key=none(PrivateKey), address=none(MultiAddress)): Switch =
@@ -466,11 +464,11 @@ suite "Waku Store":
 
     ## Send 5 ephemeral messages. A message is stateful by default.
     let msgList = @[
-        fakeWakuMessage(ephemeral = true),
-        fakeWakuMessage(ephemeral = true),
-        fakeWakuMessage(ephemeral = true),
-        fakeWakuMessage(ephemeral = true),
-        fakeWakuMessage(ephemeral = true),
+        fakeWakuMessage(ttl = some(Timestamp(0))),
+        fakeWakuMessage(ttl = some(Timestamp(0))),
+        fakeWakuMessage(ttl = some(Timestamp(0))),
+        fakeWakuMessage(ttl = some(Timestamp(0))),
+        fakeWakuMessage(ttl = some(Timestamp(0))),
       ]
 
     for msg in msgList:

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -31,6 +31,14 @@ type
     # this field will be used in the rln-relay protocol
     # XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec and not yet part of WakuMessage spec
     proof*: RateLimitProof
+    # The ephemeral field indicates if the message should
+    # be stored. bools and uints are 
+    # equivalent in serialization of the protobuf
+    ephemeral*: bool
+    # The storeTTL field indicates for how long a given message
+    # should be considered "valid", after which it may still
+    # be fetched, but should not be used in any business logic
+    storeTTL*: Timestamp
     
    
 
@@ -51,7 +59,19 @@ proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
   var proofBytes: seq[byte]
   discard ? pb.getField(21, proofBytes)
   msg.proof = ? RateLimitProof.init(proofBytes)
-  
+
+  # Behaviour of ephemeral with storeTTL to be defined,
+  # If a message is marked ephemeral, it should not have a storeTTL.
+  # If a message is not marked ephemeral, it should have a storeTTL.
+  # How would we handle messages that should be stored permanently?
+  var ephemeral: uint
+  discard ? pb.getField(31, ephemeral)
+  msg.ephemeral = uintToBool(ephemeral)
+
+  var storeTTL: zint64
+  discard ? pb.getField(32, storeTTL)
+  msg.storeTTL = Timestamp(storeTTL)
+
   ok(msg)
 
 proc encode*(message: WakuMessage): ProtoBuffer =
@@ -62,6 +82,8 @@ proc encode*(message: WakuMessage): ProtoBuffer =
   result.write3(3, message.version)
   result.write3(10, zint64(message.timestamp))
   result.write3(21, message.proof.encode())
+  result.write3(31, boolToUint(message.ephemeral))
+  result.write3(32, zint64(message.storeTTL))
   
   result.finish3()
 

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -13,8 +13,7 @@ import
   libp2p/varint,
   ../utils/protobuf,
   ../utils/time,
-  waku_rln_relay/waku_rln_relay_types,
-  std/options
+  waku_rln_relay/waku_rln_relay_types
 
 const
   MaxWakuMessageSize* = 1024 * 1024 # In bytes. Corresponds to PubSub default
@@ -32,20 +31,20 @@ type
     # this field will be used in the rln-relay protocol
     # XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec and not yet part of WakuMessage spec
     proof*: RateLimitProof
-    # The ttl field indicates the time-to-live of the message
-    # It is a unix timestamp in nanoseconds
-    # There are three cases:
-    # 1. ttl = undefined, which means that the message is valid forever (for backwards compat)
-    # 2. ttl = 0, which means that the message is ephemeral
-    # 3. ttl > now() + T, which means that the message is valid till ttl
-    ttl*: Option[Timestamp]
-
+    # The ephemeral field indicates if the message should
+    # be stored. bools and uints are 
+    # equivalent in serialization of the protobuf
+    ephemeral*: bool
+    # The storeTTL field indicates for how long a given message
+    # should be considered "valid", after which it may still
+    # be fetched, but should not be used in any business logic
+    storeTTL*: Timestamp
     
    
 
 # Encoding and decoding -------------------------------------------------------
 proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
-  var msg = WakuMessage(ttl: none(Timestamp))
+  var msg = WakuMessage()
   let pb = initProtoBuffer(buffer)
 
   discard ? pb.getField(1, msg.payload)
@@ -61,14 +60,19 @@ proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
   discard ? pb.getField(21, proofBytes)
   msg.proof = ? RateLimitProof.init(proofBytes)
 
-  var ttl: zint64
-  if ? pb.getField(31, ttl):
-    msg.ttl = some(Timestamp(ttl))
+  # Behaviour of ephemeral with storeTTL to be defined,
+  # If a message is marked ephemeral, it should not have a storeTTL.
+  # If a message is not marked ephemeral, it should have a storeTTL.
+  # How would we handle messages that should be stored permanently?
+  var ephemeral: uint
+  discard ? pb.getField(31, ephemeral)
+  msg.ephemeral = uintToBool(ephemeral)
+
+  var storeTTL: zint64
+  discard ? pb.getField(32, storeTTL)
+  msg.storeTTL = Timestamp(storeTTL)
 
   ok(msg)
-
-proc encode*(timestamp: Timestamp): zint64 =
-  zint64(timestamp)
 
 proc encode*(message: WakuMessage): ProtoBuffer =
   result = initProtoBuffer()
@@ -76,12 +80,10 @@ proc encode*(message: WakuMessage): ProtoBuffer =
   result.write3(1, message.payload)
   result.write3(2, message.contentTopic)
   result.write3(3, message.version)
-  result.write3(10, message.timestamp.encode())
+  result.write3(10, zint64(message.timestamp))
   result.write3(21, message.proof.encode())
-
-  if message.ttl.isSome():
-    result.write3(31, message.ttl.get().encode())
-
+  result.write3(31, boolToUint(message.ephemeral))
+  result.write3(32, zint64(message.storeTTL))
   
   result.finish3()
 

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -35,10 +35,6 @@ type
     # be stored. bools and uints are 
     # equivalent in serialization of the protobuf
     ephemeral*: bool
-    # The storeTTL field indicates for how long a given message
-    # should be considered "valid", after which it may still
-    # be fetched, but should not be used in any business logic
-    storeTTL*: Timestamp
     
    
 

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -204,6 +204,10 @@ proc handleMessage*(w: WakuStore, topic: string, msg: WakuMessage) {.async.} =
     # Store is mounted but new messages should not be stored
     return
 
+  if msg.ephemeral:
+    # The message is ephemeral, should not be stored
+    return
+
   let index = Index.compute(
     msg,
     receivedTime = getNanosecondTime(getTime().toUnixFloat()),

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -204,13 +204,19 @@ proc handleMessage*(w: WakuStore, topic: string, msg: WakuMessage) {.async.} =
     # Store is mounted but new messages should not be stored
     return
 
-  if msg.ephemeral:
-    # The message is ephemeral, should not be stored
-    return
+  if msg.ttl.isSome():
+    let ttl = msg.ttl.get()
+    if ttl == 0:
+      # The message is ephemeral, should not be stored
+      return
+    # else:
+      # The message is ephemeral, but should be stored for a limited time
+      # TODO: Add check here for ttl validity
 
+  let receivedTime = getNanosecondTime(getTime().toUnixFloat())
   let index = Index.compute(
     msg,
-    receivedTime = getNanosecondTime(getTime().toUnixFloat()),
+    receivedTime = receivedTime,
     pubsubTopic = topic
   )
 
@@ -234,7 +240,9 @@ proc handleMessage*(w: WakuStore, topic: string, msg: WakuMessage) {.async.} =
   if res.isErr():
     debug "failed to store messages", err=res.error()
     waku_store_errors.inc(labelValues = [storeFailure])
-
+  # elif shouldCleanupMessage:
+    # TODO: set timer to delete message from store
+    
 
 # TODO: Remove after converting the query method into a non-callback method
 type QueryHandlerFunc* = proc(response: HistoryResponse) {.gcsafe, closure.}

--- a/waku/v2/utils/protobuf.nim
+++ b/waku/v2/utils/protobuf.nim
@@ -18,9 +18,3 @@ proc finish3*(proto: var ProtoBuffer) =
 
 proc `==`*(a: zint64, b: zint64): bool =
   int64(a) == int64(b)
-
-proc uintToBool*(value: uint64): bool =
-  value != 0
-
-proc boolToUint*(value: bool): uint =
-  if value: 1 else: 0

--- a/waku/v2/utils/protobuf.nim
+++ b/waku/v2/utils/protobuf.nim
@@ -18,3 +18,9 @@ proc finish3*(proto: var ProtoBuffer) =
 
 proc `==`*(a: zint64, b: zint64): bool =
   int64(a) == int64(b)
+
+proc uintToBool*(value: uint64): bool =
+  value != 0
+
+proc boolToUint*(value: bool): uint =
+  if value: 1 else: 0


### PR DESCRIPTION
Should resolve #985.

Follows the RFC change described in [vacp2p/rfc](https://github.com/vacp2p/rfc/pull/532)