### PR TITLE
fix(waku-store): added an index to improve messages query time

### DIFF
--- a/waku/v2/node/storage/message/waku_message_store_queries.nim
+++ b/waku/v2/node/storage/message/waku_message_store_queries.nim
@@ -76,7 +76,7 @@ proc createTable*(db: SqliteDatabase): DatabaseResult[void] {.inline.} =
 ## Create index
 
 template createIndexQuery(table: string): SqlQueryStr = 
-  "CREATE INDEX IF NOT EXISTS i_rt ON " & table & " (receiverTimestamp);"
+  "CREATE INDEX IF NOT EXISTS i_msg ON " & table & " (contentTopic, pubsubTopic, senderTimestamp, id);"
 
 proc createIndex*(db: SqliteDatabase): DatabaseResult[void] {.inline.} =
   let query = createIndexQuery(DbTable)

--- a/waku/v2/node/storage/migration/migration_types.nim
+++ b/waku/v2/node/storage/migration/migration_types.nim
@@ -7,7 +7,7 @@ const MESSAGE_STORE_MIGRATION_PATH* = sourceDir / "migrations_scripts/message"
 const PEER_STORE_MIGRATION_PATH* = sourceDir / "migrations_scripts/peer"
 const ALL_STORE_MIGRATION_PATH* = sourceDir / "migrations_scripts"
 
-const USER_VERSION* = 4 # increase this when there is an update in the database schema
+const USER_VERSION* = 5 # increase this when there is an update in the database schema
 
 type MigrationScriptsResult*[T] = Result[T, string]
 type

--- a/waku/v2/node/storage/migration/migrations_scripts/message/00005_updateIndex.up.sql
+++ b/waku/v2/node/storage/migration/migrations_scripts/message/00005_updateIndex.up.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS i_rt;
+
+CREATE INDEX IF NOT EXISTS i_msg ON Message (contentTopic, pubsubTopic, senderTimestamp, id);


### PR DESCRIPTION
This PR contains surgical changes to unblock Status's waku store testing. Some deficiencies have been identified during the analysis and will be addressed shortly.

The existing SQLite index of the messages table, `i_rt`, was not helpful for the store queries. 

- [x] Added a DB migration and increased the database schema version: 
	* Drop the previous `i_rt` index
	* Create a new index, `i_msg`, that contains the fields relevant to the store query
- [x] Update the messages index creation query

