### PR TITLE
refactor(wakunode): split wakunode lightpush tests into a new file

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -3,6 +3,7 @@ import
   # TODO: enable this when it is altered into a proper waku relay test
   # ./v2/test_waku,
   ./v2/test_wakunode,
+  ./v2/test_wakunode_lightpush,
   ./v2/test_waku_store_rpc_codec,
   ./v2/test_waku_store,
   ./v2/test_waku_filter,

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -18,7 +18,6 @@ import
   ../../waku/v2/protocol/[waku_relay, waku_message],
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_filter,
-  ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
   ../../waku/v2/utils/pagination,
@@ -673,76 +672,6 @@ procSuite "WakuNode":
 
     await allFutures([node1.stop(), node2.stop()])
 
-  asyncTest "Lightpush message return success":
-    let
-      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        Port(60010))
-      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
-        Port(60012))
-      nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"),
-        Port(60013))
-      pubSubTopic = "test"
-      contentTopic = ContentTopic("/waku/2/default-content/proto")
-      payload = "hello world".toBytes()
-      message = WakuMessage(payload: payload, contentTopic: contentTopic)
-
-    # Light node, only lightpush
-    await node1.start()
-    await node1.mountLightPush()
-
-    # Intermediate node
-    await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
-    await node2.mountLightPush()
-
-    # Receiving node
-    await node3.start()
-    await node3.mountRelay(@[pubSubTopic])
-
-    discard await node1.peerManager.dialPeer(node2.switch.peerInfo.toRemotePeerInfo(), WakuLightPushCodec)
-    await sleepAsync(5.seconds)
-    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
-
-    var completionFutLightPush = newFuture[bool]()
-    var completionFutRelay = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
-      completionFutRelay.complete(true)
-
-    node3.subscribe(pubSubTopic, relayHandler)
-    await sleepAsync(2000.millis)
-
-    proc handler(response: PushResponse) {.gcsafe, closure.} =
-      debug "push response handler, expecting true"
-      check:
-        response.isSuccess == true
-      completionFutLightPush.complete(true)
-
-    # Publishing with lightpush
-    await node1.lightpush(pubSubTopic, message, handler)
-    await sleepAsync(2000.millis)
-
-    check:
-      (await completionFutRelay.withTimeout(5.seconds)) == true
-      (await completionFutLightPush.withTimeout(5.seconds)) == true
-
-    await allFutures([node1.stop(), node2.stop(), node3.stop()])
-
-  #   check:
-  #     (await completionFutRelay.withTimeout(5.seconds)) == true
-  #     (await completionFutLightPush.withTimeout(5.seconds)) == true
-  #   await node1.stop()
-  #   await node2.stop()
-  #   await node3.stop()
   asyncTest "Resume proc fetches the history":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -1,0 +1,82 @@
+{.used.}
+
+import
+  stew/byteutils, 
+  stew/shims/net as stewNet, 
+  testutils/unittests,
+  chronicles, 
+  chronos, 
+  libp2p/crypto/crypto,
+  libp2p/switch,
+  ../../waku/v2/protocol/waku_lightpush,
+  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/utils/peers,
+  ../../waku/v2/node/wakunode2
+
+
+procSuite "WakuNode - Lightpush":
+  let rng = crypto.newRng()
+ 
+  asyncTest "Lightpush message return success":
+    let
+      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60010))
+      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60012))
+      nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60013))
+
+    let
+      pubSubTopic = "test"
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
+      payload = "hello world".toBytes()
+      message = WakuMessage(payload: payload, contentTopic: contentTopic)
+
+    # Light node, only lightpush
+    await node1.start()
+    await node1.mountLightPush()
+
+    # Intermediate node
+    await node2.start()
+    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountLightPush()
+
+    # Receiving node
+    await node3.start()
+    await node3.mountRelay(@[pubSubTopic])
+
+    discard await node1.peerManager.dialPeer(node2.switch.peerInfo.toRemotePeerInfo(), WakuLightPushCodec)
+    await sleepAsync(1.seconds)
+    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+
+    var completionFutLightPush = newFuture[bool]()
+    var completionFutRelay = newFuture[bool]()
+    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+      let msg = WakuMessage.init(data)
+      if msg.isOk():
+        let val = msg.value()
+        check:
+          topic == pubSubTopic
+          val.contentTopic == contentTopic
+          val.payload == payload
+      completionFutRelay.complete(true)
+
+    node3.subscribe(pubSubTopic, relayHandler)
+    await sleepAsync(500.millis)
+
+    proc handler(response: PushResponse) {.gcsafe, closure.} =
+      debug "push response handler, expecting true"
+      check:
+        response.isSuccess == true
+      completionFutLightPush.complete(true)
+
+    # Publishing with lightpush
+    await node1.lightpush(pubSubTopic, message, handler)
+    await sleepAsync(500.millis)
+
+    check:
+      (await completionFutRelay.withTimeout(1.seconds)) == true
+      (await completionFutLightPush.withTimeout(1.seconds)) == true
+
+    await allFutures([node1.stop(), node2.stop(), node3.stop()])
+  


### PR DESCRIPTION
This is another short PR of a series of changes that aim to split the `test_wakunode.nim` file into different files:

- [X] Peer utils tests
- [x] RLN relay tests
- [x] Lightpush tests 
- [ ] Filter tests
- [ ] Store tests
- [ ] Relay tests
