### PR TITLE
chore: always include node ENR in response to info requests

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -414,8 +414,7 @@ proc info*(node: WakuNode): WakuInfo =
   for address in node.announcedAddresses:
     var fulladdr = $address & "/p2p/" & $peerInfo.peerId
     listenStr &= fulladdr
-  let enrUri = if node.wakuDiscV5 != nil: node.wakuDiscV5.protocol.localNode.record.toUri()
-               else: node.enr.toUri()
+  let enrUri = node.enr.toUri()
   let wakuInfo = WakuInfo(listenAddresses: listenStr, enrUri: enrUri)
   return wakuInfo
 


### PR DESCRIPTION
Blocks: https://github.com/status-im/infra-status/issues/15

Since the `node.enr` is:
- always available
- more complete than the `wakuDiscv5` enr
I believe it's sensible to always include this ENR in responses to info requests. Once [the ENRs are consolidated](https://github.com/status-im/nwaku/issues/915), we can include only the consolidated ENR here (which is likely to be `node.enr` in any case).

This is necessary to extract ENRs for DNS discovery purposes: https://github.com/status-im/infra-status/issues/15