### PR TITLE
fix(store): add a table index to improve message insertion time

### DIFF
--- a/waku/v2/node/storage/migration/migrations_scripts/message/00005_updateIndex.up.sql
+++ b/waku/v2/node/storage/migration/migrations_scripts/message/00005_updateIndex.up.sql
@@ -1,3 +1,1 @@
-DROP INDEX IF EXISTS i_rt;
-
 CREATE INDEX IF NOT EXISTS i_msg ON Message (contentTopic, pubsubTopic, senderTimestamp, id);

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -212,23 +212,23 @@ proc handleMessage*(w: WakuStore, topic: string, msg: WakuMessage) {.async.} =
 
   # Add message to in-memory store
   if not w.isSqliteOnly:
-    # Handle WakuMessage according to store protocol
     trace "handle message in WakuStore", topic=topic, msg=msg
 
     let addRes = w.messages.add(IndexedWakuMessage(msg: msg, index: index, pubsubTopic: topic))
     if addRes.isErr():
-      trace "Attempt to add message to store failed", msg=msg, index=index, err=addRes.error()
+      debug "Attempt to add message to store failed", msg=msg, index=index, err=addRes.error()
       waku_store_errors.inc(labelValues = [$(addRes.error())])
       return
   
     waku_store_messages.set(w.messages.len.int64, labelValues = ["stored"])
   
+  # Add messages to persistent store, if present
   if w.store.isNil:
     return
 
   let res = w.store.put(index, msg, topic)
   if res.isErr():
-    trace "failed to store messages", err=res.error()
+    debug "failed to store messages", err=res.error()
     waku_store_errors.inc(labelValues = [storeFailure])
 
 


### PR DESCRIPTION
This PR fixes a regression introduced in #1120, and solves the #1127 issue.

* Revert `i_rt` index. The index was dropped, translating into a heavy CPU load when a message was inserted.
* Replace `waku_message_store_queries.nim` templates with `proc` and remove `{.inline.}` as per [this discussion](https://github.com/status-im/nwaku/pull/1104#discussion_r959559319) in a previous PR and the [Status' nim styleguide](https://status-im.github.io/nim-style-guide/language.inline.html?highlight=inline#inline-functions-languageinline).
* Raise, temporarily, to debug the level of the insertion failures.

