### PR TITLE
fix macos builds

### DIFF
--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -108,7 +108,7 @@ def getAgentLabel() {
         return params.AGENT_LABEL
     }
     def tokens = env.JOB_NAME.split('/')
-    for (platform in ['linux', 'macos', 'windows']) {
+    for (platform in ['linux', 'macos']) {
       if (tokens.contains(platform)) { return platform }
     }
     throw new Exception('No agent provided or found in job path!')

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -108,7 +108,7 @@ def getAgentLabel() {
         return params.AGENT_LABEL
     }
     def tokens = env.JOB_NAME.split('/')
-    for (platform in ['linux', 'macos']) {
+    for (platform in ['linux', 'macos', 'windows']) {
       if (tokens.contains(platform)) { return platform }
     }
     throw new Exception('No agent provided or found in job path!')

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -159,7 +159,7 @@ const
   MERKLE_TREE_DEPTH* = 20
   # TODO the ETH_CLIENT should be an input to the rln-relay, though hardcoded for now
   # the current address is the address of ganache-cli when run locally
-  ETH_CLIENT* = "ws://localhost:8540/"
+  ETH_CLIENT* = "ws://127.0.0.1:8540"
 
 const
   # the size of poseidon hash output in bits


### PR DESCRIPTION
Should resolve #1131.

Reverts the `nim-json-rpc` submodule update, which moved from `nim-websock` to `news` between updates. Relevant [diff](https://github.com/status-im/nim-json-rpc/compare/335f292a5816910aebf215e3a88db8a665133e0e...32ba2d16b919310a8c6797ac45747595f301a207)

This regression only affects macOS.

Experimentation can be done by updating to the latest version of `nim-json-rpc`, there seems to be some work done on this [PR](https://github.com/status-im/nim-json-rpc/pull/147) to better support macOS.
