### PR TITLE
refactor(wakunode): remove exports from wakunode

### DIFF
--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -6,8 +6,8 @@ import
   libp2p/crypto/secp,
   nimcrypto/utils,
   eth/keys,
-  ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_types,
   ../../waku/v2/protocol/waku_message
+
 type
   Fleet* =  enum
     none
@@ -241,8 +241,8 @@ type
    
     rlnRelayMemIndex* {.
       desc: "(experimental) the index of node in the rln-relay group: a value between 0-99 inclusive",
-      defaultValue: MembershipIndex(0)
-      name: "rln-relay-membership-index" }: MembershipIndex
+      defaultValue: 0
+      name: "rln-relay-membership-index" }: uint
 
     rlnRelayContentTopic* {.
       desc: "the pubsub topic for which rln-relay gets enabled",

--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -11,6 +11,7 @@ import
   # Waku v2 imports
   libp2p/crypto/crypto,
   libp2p/errors,
+  ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/node/wakunode2,
   # Chat 2 imports
   ../chat2,

--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -10,6 +10,7 @@ import
   ../../../waku/common/utils/matterbridge_client,
   # Waku v2 imports
   libp2p/crypto/crypto,
+  libp2p/errors,
   ../../../waku/v2/node/wakunode2,
   # Chat 2 imports
   ../chat2,

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -20,6 +20,7 @@ import
                               filter_api,
                               admin_api,
                               private_api],
+  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_swap/waku_swap,

--- a/tests/v2/test_peer_exchange.nim
+++ b/tests/v2/test_peer_exchange.nim
@@ -6,6 +6,7 @@ import
   testutils/unittests,
   chronicles,
   chronos,
+  libp2p/peerid,
   libp2p/crypto/crypto,
   libp2p/protocols/pubsub/gossipsub
 import

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -14,6 +14,7 @@ import
   libp2p/protocols/pubsub/rpc/message
 import
   ../../waku/v2/protocol/waku_message,
+  ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_swap/waku_swap,

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -16,6 +16,7 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_filter,
+  ../../waku/v2/protocol/waku_swap/waku_swap,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/storage/peer/waku_peer_storage,
   ../../waku/v2/node/wakunode2,

--- a/tests/v2/test_rest_debug_api.nim
+++ b/tests/v2/test_rest_debug_api.nim
@@ -5,6 +5,8 @@ import
   chronicles,
   testutils/unittests,
   presto, 
+  libp2p/peerid,
+  libp2p/multiaddress,
   libp2p/crypto/crypto
 import
   ../../waku/v2/node/wakunode2,

--- a/tests/v2/test_rest_relay_api.nim
+++ b/tests/v2/test_rest_relay_api.nim
@@ -10,6 +10,7 @@ import
   libp2p/crypto/crypto,
   libp2p/protocols/pubsub/pubsub
 import
+  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/wakunode2,
   ../../waku/v2/node/rest/[server, client, base64, utils],
   ../../waku/v2/node/rest/relay/[api_types, relay_api, topic_cache]

--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -10,6 +10,7 @@ import
   libp2p/crypto/crypto,
   eth/keys,
   eth/p2p/discoveryv5/enr,
+  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/discv5/waku_discv5,
   ../../waku/v2/node/wakunode2,
   ../test_helpers

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -7,6 +7,7 @@ import
   stew/byteutils, stew/shims/net as stewNet,
   libp2p/crypto/crypto,
   json,
+  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils,
       waku_rln_relay_types],
   ../../waku/v2/node/wakunode2,

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -8,6 +8,7 @@ import
   chronos, 
   libp2p/crypto/crypto,
   libp2p/switch,
+  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -6,6 +6,8 @@ import
   metrics, metrics/chronos_httpserver,
   stew/byteutils,
   stew/shims/net as stewNet, json_rpc/rpcserver,
+  libp2p/errors,
+  libp2p/peerstore,
   # Waku v1 imports
   eth/[keys, p2p], eth/common/utils,
   eth/p2p/[enode, peer_pool],

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -18,6 +18,7 @@ import
   libp2p/nameresolving/nameresolver,
   ../v2/utils/namespacing,
   ../v2/utils/time,
+  ../v2/protocol/waku_message,
   ../v2/node/wakunode2,
   # Common cli config
   ./config_bridge

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -8,7 +8,6 @@ import
   libp2p/crypto/secp,
   nimcrypto/utils,
   eth/keys,
-  ../protocol/waku_rln_relay/waku_rln_relay_types,
   ../protocol/waku_message
 
 export
@@ -121,8 +120,8 @@ type
 
     rlnRelayMemIndex* {.
       desc: "(experimental) the index of node in the rln-relay group: a value between 0-99 inclusive",
-      defaultValue: MembershipIndex(0)
-      name: "rln-relay-membership-index" }: MembershipIndex
+      defaultValue: 0
+      name: "rln-relay-membership-index" }: uint
 
     rlnRelayPubsubTopic* {.
       desc: "the pubsub topic for which rln-relay gets enabled",

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -9,6 +9,7 @@ import
   ../../protocol/waku_message,
   ../../protocol/waku_store,
   ../../protocol/waku_filter,
+  ../../protocol/waku_swap/waku_swap,
   ../peer_manager/peer_manager,
   ../wakunode2,
   ./jsonrpc_types

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -9,6 +9,7 @@ import
   ../../protocol/waku_message,
   ../../protocol/waku_store,
   ../../protocol/waku_filter,
+  ../../protocol/waku_relay,
   ../../protocol/waku_swap/waku_swap,
   ../peer_manager/peer_manager,
   ../wakunode2,

--- a/waku/v2/node/jsonrpc/relay_api.nim
+++ b/waku/v2/node/jsonrpc/relay_api.nim
@@ -5,6 +5,7 @@ import
   chronicles,
   json_rpc/rpcserver,
   libp2p/protocols/pubsub/pubsub,
+  ../../protocol/waku_message,
   ../wakunode2,
   ./jsonrpc_types,
   ./jsonrpc_utils

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -33,7 +33,6 @@ import
 export
   builders,
   waku_relay, waku_message,
-  waku_swap,
   waku_rln_relay_types,
   wakunode2_types
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -32,7 +32,7 @@ import
 
 export
   builders,
-  waku_relay, waku_message,
+  waku_message,
   waku_rln_relay_types,
   wakunode2_types
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -31,7 +31,6 @@ import
   ./wakunode2_types
 
 export
-  waku_message,
   waku_rln_relay_types,
   wakunode2_types
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -31,7 +31,6 @@ import
   ./wakunode2_types
 
 export
-  builders,
   waku_message,
   waku_rln_relay_types,
   wakunode2_types

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -20,7 +20,7 @@ import
   ../protocol/waku_swap/waku_swap,
   ../protocol/waku_filter,
   ../protocol/waku_lightpush,
-  ../protocol/waku_rln_relay/[waku_rln_relay_types], 
+  ../protocol/waku_rln_relay/waku_rln_relay_types, 
   ../utils/[peers, requests, wakuenr],
   ./peer_manager/peer_manager,
   ./storage/message/waku_store_queue,
@@ -31,7 +31,6 @@ import
   ./wakunode2_types
 
 export
-  waku_rln_relay_types,
   wakunode2_types
 
 when defined(rln):

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -11,7 +11,8 @@ import
   ./wakunode2,
   ../protocol/waku_filter,
   ../protocol/waku_store,
-  ../protocol/waku_lightpush
+  ../protocol/waku_lightpush,
+  ../protocol/waku_swap/waku_swap
 
 logScope:
   topics = "wakunode.setup.metrics"

--- a/waku/v2/node/wakunode2_setup_rpc.nim
+++ b/waku/v2/node/wakunode2_setup_rpc.nim
@@ -7,6 +7,7 @@ import
   json_rpc/rpcserver
 import
   ./config,
+  ../protocol/waku_message,
   ./wakunode2,
   ./jsonrpc/[admin_api,
              debug_api,

--- a/waku/v2/node/wakunode2_setup_sql_migrations.nim
+++ b/waku/v2/node/wakunode2_setup_sql_migrations.nim
@@ -1,11 +1,11 @@
 {.push raises: [Defect].}
 
 import
+  stew/results,
   chronicles,
   ./storage/sqlite,
   ./storage/migration/migration_types,
-  ./config,
-  ./wakunode2
+  ./config
 
 logScope:
   topics = "wakunode.setup.migrations"
@@ -23,7 +23,7 @@ proc runMigrations*(sqliteDatabase: SqliteDatabase, conf: WakuNodeConf) =
 
   info "running migration ...", migrationPath=migrationPath
   let migrationResult = sqliteDatabase.migrate(migrationPath)
-  if migrationResult.isErr:
-    warn "migration failed", error=migrationResult.error
+  if migrationResult.isErr():
+    warn "migration failed", error=migrationResult.error()
   else:
     info "migration is done"

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1065,7 +1065,7 @@ proc mountRlnRelay*(node: WakuNode, conf: WakuNodeConf|Chat2Conf, spamHandler: O
   if not conf.rlnRelayDynamic:
     info " setting up waku-rln-relay in off-chain mode... "
     # set up rln relay inputs
-    let (groupOpt, memKeyPairOpt, memIndexOpt) = rlnRelayStaticSetUp(conf.rlnRelayMemIndex)
+    let (groupOpt, memKeyPairOpt, memIndexOpt) = rlnRelayStaticSetUp(MembershipIndex(conf.rlnRelayMemIndex))
     if memIndexOpt.isNone:
       error "failed to mount WakuRLNRelay"
     else:


### PR DESCRIPTION
Another multi-commit grooming PR. In this case, the goal is to continue removing the exports to avoid implicit and cyclic imports.