### PR TITLE
feat(store): run sqlite database vacuum at node start

### DIFF
--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -68,6 +68,11 @@ type
       desc: "The database path for peristent storage",
       defaultValue: ""
       name: "db-path" }: string
+
+    dbVacuum* {.
+      desc: "Enable database vacuuming at start: true|false",
+      defaultValue: false
+      name: "db-vacuum" }: bool
     
     persistPeers* {.
       desc: "Enable peer persistence: true|false",


### PR DESCRIPTION
This PR partially covers #1154 

* Log some metrics related to SQLite database pages
* Added a flag to enable vacuuming. Disabled by default.
* Executes SQLite's `VACUUM` command during storage setup, right before running any DB migration.