### PR TITLE
feat(rln-relay): validate the merkle root in the RateLimitProof

### DIFF
--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -686,9 +686,8 @@ suite "Waku rln relay":
       validProofRes.isOk()
     let validProof = validProofRes.value
 
-    # verify the proof (should be verified)
-    let verified = rln.proofVerify(data = messageBytes,
-                                  proof = validProof)
+    # validate the root (should be true)
+    let verified = rln.validateRoot(validProof.merkleRoot)
 
     require:
       verified.isOk()
@@ -713,8 +712,7 @@ suite "Waku rln relay":
     # we try to verify a proof against this new merkle tree,
     # which should return false
     # Try to send a message constructed with an older root
-    let olderRootVerified = rln.proofVerify(data = messageBytes,
-                                            proof = validProof)
+    let olderRootVerified = rln.validateRoot(validProof.merkleRoot)
 
     require:
       olderRootVerified.isOk()

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -584,8 +584,6 @@ suite "Waku rln relay":
 
     check:
       verified.isOk()
-
-    check:
       verified.value() == true
 
   test "test proofVerify and proofGen for an invalid proof":
@@ -637,7 +635,6 @@ suite "Waku rln relay":
                                   proof = proof)
     check:
       verified.isOk()
-    check:
       verified.value() == false
 
   test "invalidate messages with a valid, but stale root":
@@ -688,7 +685,6 @@ suite "Waku rln relay":
 
     check:
       verified.isOk()
-    check:
       verified.value() == true
 
     # Progress the local tree by removing a member
@@ -699,8 +695,6 @@ suite "Waku rln relay":
 
     check:
       currentMerkleRoot.isOk()
-
-    check:
       currentMerkleRoot.value() != validProof.merkleRoot
 
     # Try to send a message constructed with an older root
@@ -709,7 +703,6 @@ suite "Waku rln relay":
 
     check:
       olderRootVerified.isOk()
-    check:
       olderRootVerified.value() == false
 
   test "toEpoch and fromEpoch consistency check":

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -800,7 +800,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
       return MessageValidationResult.Invalid
 
   if not merkleRootIsValidRes.value():
-      debug "invalid message: received root does not match local root", received=msg.proof.merkleRoot, local=rlnInstance.getMerkleRoot().value()
+      debug "invalid message: received root does not match local root", payload = string.fromBytes(msg.payload)
       return MessageValidationResult.Invalid
 
   let proofVerificationRes = rlnPeer.rlnInstance.proofVerify(input, msg.proof)

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -520,7 +520,7 @@ when defined(rlnzerokit):
 
   proc validateRoot*(rlnInstance: ptr RLN, proof: MerkleNode): RlnRelayResult[bool] =
     # Validate against the local merkle tree
-    let localTreeRoot = rlnInstance.getMerkleRoot()
+    let localTreeRoot = rln.getMerkleRoot()
     if not localTreeRoot.isOk():
       return err(localTreeRoot.error())
     if localTreeRoot.value() == merkleRoot:

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -391,9 +391,11 @@ when defined(rln) or (not defined(rln) and not defined(rlnzerokit)):
     var
       root {.noinit.}: Buffer = Buffer()
       rootPtr = addr(root)
-      getRootSuccessful = get_root(rlnInstance, rootPtr)
-    if (not getRootSuccessful): return err("could not get the root")
-    if (not (root.len == 32)): return err("wrong output size")
+      getRootSuccessful = getRoot(rlnInstance, rootPtr)
+    if not getRootSuccessful: 
+      return err("could not get the root")
+    if not root.len == 32:
+      return err("wrong output size")
 
     var rootValue = cast[ptr MerkleNode] (root.`ptr`)[]
     return ok(rootValue)
@@ -580,9 +582,11 @@ when defined(rlnzerokit):
     var
       root {.noinit.}: Buffer = Buffer()
       rootPtr = addr(root)
-      getRootSuccessful = get_root(rlnInstance, rootPtr)
-    if (not getRootSuccessful): return err("could not get the root")
-    if (not (root.len == 32)): return err("wrong output size")
+      getRootSuccessful = getRoot(rlnInstance, rootPtr)
+    if not getRootSuccessful: 
+      return err("could not get the root")
+    if not root.len == 32:
+      return err("wrong output size")
 
     var rootValue = cast[ptr MerkleNode] (root.`ptr`)[]
     return ok(rootValue)

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -788,22 +788,21 @@ proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
         payload = string.fromBytes(msg.payload)
     return MessageValidationResult.Invalid
 
-  # verify the proof
-  let
-    contentTopicBytes = msg.contentTopic.toBytes
-    input = concat(msg.payload, contentTopicBytes)
-  
   let merkleRootIsValidRes = rlnPeer.rlnInstance.validateRoot(msg.proof.merkleRoot)
 
   if merkleRootIsValidRes.isErr():
-      debug "invalid message: could not compute root"
+      debug "invalid message: could not validate the root"
       return MessageValidationResult.Invalid
 
   if not merkleRootIsValidRes.value():
       debug "invalid message: received root does not match local root", payload = string.fromBytes(msg.payload)
       return MessageValidationResult.Invalid
 
-  let proofVerificationRes = rlnPeer.rlnInstance.proofVerify(input, msg.proof)
+  # verify the proof
+  let
+    contentTopicBytes = msg.contentTopic.toBytes
+    input = concat(msg.payload, contentTopicBytes)
+    proofVerificationRes = rlnPeer.rlnInstance.proofVerify(input, msg.proof)
 
   if proofVerificationRes.isErr():
     return MessageValidationResult.Invalid

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1119,9 +1119,9 @@ proc mountRlnRelay*(node: WakuNode, conf: WakuNodeConf|Chat2Conf, spamHandler: O
         expectedRoot = STATIC_GROUP_MERKLE_ROOT
       
       if rootRes.isErr():
-        return err(root.getError())
+        return err(rootRes.error())
       
-      let root = rootRes.value()
+      let root = rootRes.value().toHex
 
       if root != expectedRoot:
         error "root mismatch: something went wrong not in Merkle tree construction"

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1138,7 +1138,7 @@ proc mountRlnRelay*(node: WakuNode, conf: WakuNodeConf|Chat2Conf, spamHandler: O
       
       let root = rootRes.value()
 
-      if root != expectedRoot:
+      if root.toHex != expectedRoot:
         error "root mismatch: something went wrong not in Merkle tree construction"
       debug "the calculated root", root
       info "WakuRLNRelay is mounted successfully", pubsubtopic=conf.rlnRelayPubsubTopic, contentTopic=conf.rlnRelayContentTopic

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1115,8 +1115,14 @@ proc mountRlnRelay*(node: WakuNode, conf: WakuNodeConf|Chat2Conf, spamHandler: O
       # no error should happen as it is already captured in the unit tests
       # TODO have added this check to account for unseen corner cases, will remove it later 
       let 
-        root = node.wakuRlnRelay.rlnInstance.getMerkleRoot.value.toHex() 
+        rootRes = node.wakuRlnRelay.rlnInstance.getMerkleRoot()
         expectedRoot = STATIC_GROUP_MERKLE_ROOT
+      
+      if rootRes.isErr():
+        return err(root.getError())
+      
+      let root = rootRes.value()
+
       if root != expectedRoot:
         error "root mismatch: something went wrong not in Merkle tree construction"
       debug "the calculated root", root


### PR DESCRIPTION
Should resolve #1049.

Note: There is no functionality for maintaining a window of acceptable tree roots. Should we track this in a separate issue? 

Edit: As @jm-clius pointed out in https://github.com/status-im/nwaku/pull/1158#discussion_r972237018, errors should be better handled when dealing with the `proofVerify` function. Instead of returning `false` when one of the rln libs throw errors, we throw errors. This PR also includes this change.