### PR TITLE
fix: nodes in AddressBook are not necessarily connected

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -707,7 +707,7 @@ proc runDiscv5Loop(node: WakuNode) {.async.} =
       trace "Discovered peers", count=discoveredPeers.get().len()
 
       let newPeers = discoveredPeers.get().filterIt(
-        not node.switch.peerStore[AddressBook].contains(it.peerId))
+        not node.switch.isConnected(it.peerId))
 
       if newPeers.len > 0:
         debug "Connecting to newly discovered peers", count=newPeers.len()


### PR DESCRIPTION
One-liner fix for issue that prevented the node to reconnect to peers from the discv5 loop. Peers that appear in the `AddressBook` are not necessarily connected anymore (e.g. they may have restarted) and a reconnect should be attempted when they are discovered "again" via Discovery v5.

Can confirm improvement on my own deployed node - previously if the fleet restarted the running node would never attempt to reconnect.