### PR TITLE
refactor(store): don't cache the message count in sqlite message store

### DIFF
--- a/waku/v2/node/storage/message/message_store.nim
+++ b/waku/v2/node/storage/message/message_store.nim
@@ -46,4 +46,4 @@ method getMessagesByHistoryQuery*(
   ascendingOrder = true
 ): MessageStoreResult[MessageStorePage] {.base.} = discard
 
-method getMessagesCount*(ms: MessageStore): int64 {.base.} = discard
+method getMessagesCount*(ms: MessageStore): MessageStoreResult[int64] {.base.} = discard

--- a/waku/v2/node/storage/message/waku_store_queue.nim
+++ b/waku/v2/node/storage/message/waku_store_queue.nim
@@ -426,5 +426,7 @@ method getMessagesByHistoryQuery*(
   
   ok((messages, some(pagingInfo)))
 
-method getMessagesCount*(storeQueue: StoreQueueRef): int64 =
-  int64(storeQueue.len())
+
+method getMessagesCount*(s: StoreQueueRef): MessageStoreResult[int64] =
+  ok(int64(s.len()))
+


### PR DESCRIPTION
The present PR forms part of a series of refactoring PRs that aim to decouple the retention policy from the message store interface completely.

* Make message store interface `getMessagesCount` method fallible
* Do not cache SQLite's store message count

This is part of the groundwork necessary for #1155
