### PR TITLE
refactor(store): extend message store interface with store manipulation methods

### DIFF
--- a/waku/v2/node/storage/message/message_store.nim
+++ b/waku/v2/node/storage/message/message_store.nim
@@ -46,4 +46,16 @@ method getMessagesByHistoryQuery*(
   ascendingOrder = true
 ): MessageStoreResult[MessageStorePage] {.base.} = discard
 
+
+# Store manipulation
+
 method getMessagesCount*(ms: MessageStore): MessageStoreResult[int64] {.base.} = discard
+
+method getOldestMessageTimestamp*(ms: MessageStore): MessageStoreResult[Timestamp] {.base.} = discard
+
+method getNewestMessageTimestamp*(ms: MessageStore): MessageStoreResult[Timestamp]  {.base.} = discard
+
+
+method deleteMessagesOlderThanTimestamp*(ms: MessageStore, ts: Timestamp): MessageStoreResult[void] {.base.} = discard
+
+method deleteOldestMessagesNotWithinLimit*(ms: MessageStore, limit: int): MessageStoreResult[void] {.base.} = discard

--- a/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
+++ b/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
@@ -158,3 +158,16 @@ method getMessagesByHistoryQuery*(
 
 method getMessagesCount*(s: SqliteStore): MessageStoreResult[int64] =
   s.db.getMessageCount()
+
+method getOldestMessageTimestamp*(s: SqliteStore): MessageStoreResult[Timestamp] =
+  s.db.selectOldestReceiverTimestamp()
+
+method getNewestMessageTimestamp*(s: SqliteStore): MessageStoreResult[Timestamp] =
+  s.db.selectnewestReceiverTimestamp()
+
+
+method deleteMessagesOlderThanTimestamp*(s: SqliteStore, ts: Timestamp): MessageStoreResult[void] =
+  s.db.deleteMessagesOlderThanTimestamp(ts)
+
+method deleteOldestMessagesNotWithinLimit*(s: SqliteStore, limit: int): MessageStoreResult[void] =
+  s.db.deleteOldestMessagesNotWithinLimit(limit)

--- a/waku/v2/node/storage/message/waku_store_queue.nim
+++ b/waku/v2/node/storage/message/waku_store_queue.nim
@@ -430,3 +430,17 @@ method getMessagesByHistoryQuery*(
 method getMessagesCount*(s: StoreQueueRef): MessageStoreResult[int64] =
   ok(int64(s.len()))
 
+method getOldestMessageTimestamp*(s: StoreQueueRef): MessageStoreResult[Timestamp] =
+  s.first().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)
+
+method getNewestMessageTimestamp*(s: StoreQueueRef): MessageStoreResult[Timestamp] =
+  s.last().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)
+
+
+method deleteMessagesOlderThanTimestamp*(s: StoreQueueRef, ts: Timestamp): MessageStoreResult[void] =
+  # TODO: Implement this message_store method
+  err("interface method not implemented")
+
+method deleteOldestMessagesNotWithinLimit*(s: StoreQueueRef, limit: int): MessageStoreResult[void] =
+  # TODO: Implement this message_store method
+  err("interface method not implemented")


### PR DESCRIPTION
The present PR forms part of a series of refactoring PRs that aim to decouple the retention policy from the message store interface completely.

* Extend message store interface
* Implement the message store interface methods for `SqliteStore`
* Implement the message store interface methods for `StoreQueueRef`

**NOTE:** A couple of in-memory store methods have not been implemented. Some extra work is needed there to support message retention policies.

This is part of the groundwork necessary for #1155 