### PR TITLE
feat(store): execute retention policies periodically (#1155)

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -258,7 +258,7 @@ procSuite "Waku v2 JSON-RPC API":
         WakuMessage(payload: @[byte 9], contentTopic: ContentTopic("2"), timestamp: 9)]
 
     for wakuMsg in msgList:
-      waitFor node.wakuStore.handleMessage(defaultTopic, wakuMsg)
+      node.wakuStore.handleMessage(defaultTopic, wakuMsg)
 
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort, false)

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -97,8 +97,8 @@ suite "Waku Store":
       msg1 = fakeWakuMessage(contentTopic=topic)
       msg2 = fakeWakuMessage()
 
-    await serverProto.handleMessage("foo", msg1)
-    await serverProto.handleMessage("foo", msg2)
+    serverProto.handleMessage("foo", msg1)
+    serverProto.handleMessage("foo", msg2)
 
     ## When
     let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: topic)])
@@ -141,9 +141,9 @@ suite "Waku Store":
       msg2 = fakeWakuMessage(contentTopic=topic2)
       msg3 = fakeWakuMessage(contentTopic=topic3)
 
-    await serverProto.handleMessage("foo", msg1)
-    await serverProto.handleMessage("foo", msg2)
-    await serverProto.handleMessage("foo", msg3)
+    serverProto.handleMessage("foo", msg1)
+    serverProto.handleMessage("foo", msg2)
+    serverProto.handleMessage("foo", msg3)
     
     ## When
     let rpc = HistoryQuery(contentFilters: @[
@@ -194,9 +194,9 @@ suite "Waku Store":
       msg2 = fakeWakuMessage(contentTopic=contentTopic2)
       msg3 = fakeWakuMessage(contentTopic=contentTopic3)
 
-    await serverProto.handleMessage(pubsubtopic1, msg1)
-    await serverProto.handleMessage(pubsubtopic2, msg2)
-    await serverProto.handleMessage(pubsubtopic2, msg3)
+    serverProto.handleMessage(pubsubtopic1, msg1)
+    serverProto.handleMessage(pubsubtopic2, msg2)
+    serverProto.handleMessage(pubsubtopic2, msg3)
     
     ## When
     # this query targets: pubsubtopic1 AND (contentTopic1 OR contentTopic3)    
@@ -243,9 +243,9 @@ suite "Waku Store":
       msg2 = fakeWakuMessage()
       msg3 = fakeWakuMessage()
 
-    await serverProto.handleMessage(pubsubtopic2, msg1)
-    await serverProto.handleMessage(pubsubtopic2, msg2)
-    await serverProto.handleMessage(pubsubtopic2, msg3)
+    serverProto.handleMessage(pubsubtopic2, msg1)
+    serverProto.handleMessage(pubsubtopic2, msg2)
+    serverProto.handleMessage(pubsubtopic2, msg3)
 
     ## When
     let rpc = HistoryQuery(pubsubTopic: pubsubTopic1)
@@ -284,9 +284,9 @@ suite "Waku Store":
       msg2 = fakeWakuMessage(payload="TEST-2")
       msg3 = fakeWakuMessage(payload="TEST-3")
 
-    await serverProto.handleMessage(pubsubTopic, msg1)
-    await serverProto.handleMessage(pubsubTopic, msg2)
-    await serverProto.handleMessage(pubsubTopic, msg3)
+    serverProto.handleMessage(pubsubTopic, msg1)
+    serverProto.handleMessage(pubsubTopic, msg2)
+    serverProto.handleMessage(pubsubTopic, msg3)
     
     ## When
     let rpc = HistoryQuery(pubsubTopic: pubsubTopic)
@@ -335,7 +335,7 @@ suite "Waku Store":
       ]
 
     for msg in msgList:
-      await serverProto.handleMessage("foo", msg)
+      serverProto.handleMessage("foo", msg)
 
     ## When
     let rpc = HistoryQuery(
@@ -387,7 +387,7 @@ suite "Waku Store":
       ]
 
     for msg in msgList:
-      await serverProto.handleMessage("foo", msg)
+      serverProto.handleMessage("foo", msg)
 
     ## When
     let rpc = HistoryQuery(
@@ -439,7 +439,7 @@ suite "Waku Store":
       ]
 
     for msg in msgList:
-      await serverProto.handleMessage("foo", msg)
+      serverProto.handleMessage("foo", msg)
 
     ## When
     let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: DefaultContentTopic)])
@@ -475,7 +475,7 @@ suite "Waku Store":
     ]
 
     for msg in msgList:
-      await proto.handleMessage(DefaultPubsubTopic, msg)
+      proto.handleMessage(DefaultPubsubTopic, msg)
 
     check: 
       store.len == 2
@@ -529,7 +529,7 @@ procSuite "Waku Store - fault tolerant store":
     ]
 
     for msg in msgList:
-      await proto.handleMessage(DefaultPubsubTopic, msg)
+      proto.handleMessage(DefaultPubsubTopic, msg)
 
     let (listenSwitch2, dialSwitch2, proto2) = await newTestWakuStore()
     let msgList2 = @[
@@ -544,7 +544,7 @@ procSuite "Waku Store - fault tolerant store":
     ]
 
     for msg in msgList2:
-      await proto2.handleMessage(DefaultPubsubTopic, msg)
+      proto2.handleMessage(DefaultPubsubTopic, msg)
 
     
     asyncTest "handle temporal history query with a valid time window":

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -70,7 +70,7 @@ procSuite "Waku SWAP Accounting":
     await node2.mountSwap()
     await node2.mountStore(store=StoreQueueRef.new())
 
-    await node2.wakuStore.handleMessage("/waku/2/default-waku/proto", message)
+    node2.wakuStore.handleMessage("/waku/2/default-waku/proto", message)
 
     await sleepAsync(500.millis)
 
@@ -120,7 +120,7 @@ procSuite "Waku SWAP Accounting":
     await node2.mountSwap(swapConfig)
     await node2.mountStore(store=StoreQueueRef.new())
 
-    await node2.wakuStore.handleMessage("/waku/2/default-waku/proto", message)
+    node2.wakuStore.handleMessage("/waku/2/default-waku/proto", message)
 
     await sleepAsync(500.millis)
 

--- a/tests/v2/test_wakunode_store.nim
+++ b/tests/v2/test_wakunode_store.nim
@@ -54,7 +54,7 @@ procSuite "WakuNode - Store":
     await node2.start()
     await node2.mountStore(store=newTestMessageStore())
 
-    await node2.wakuStore.handleMessage("/waku/2/default-waku/proto", message)
+    node2.wakuStore.handleMessage("/waku/2/default-waku/proto", message)
 
     await sleepAsync(500.millis)
 
@@ -149,7 +149,7 @@ procSuite "WakuNode - Store":
     await node2.start()
     await node2.mountStore(store=StoreQueueRef.new())
 
-    await node2.wakuStore.handleMessage("/waku/2/default-waku/proto", message)
+    node2.wakuStore.handleMessage("/waku/2/default-waku/proto", message)
 
     await sleepAsync(500.millis)
 
@@ -182,8 +182,8 @@ procSuite "WakuNode - Store":
     await client.mountStore(store=StoreQueueRef.new())
     await server.mountStore(store=StoreQueueRef.new())
 
-    await server.wakuStore.handleMessage(DefaultTopic, msg1)
-    await server.wakuStore.handleMessage(DefaultTopic, msg2)
+    server.wakuStore.handleMessage(DefaultTopic, msg1)
+    server.wakuStore.handleMessage(DefaultTopic, msg2)
 
     client.wakuStore.setPeer(server.switch.peerInfo.toRemotePeerInfo())
 


### PR DESCRIPTION
This PR resolves #1155: Reduce the message insertion duration by running the retention policy in a periodic task instead running it at insertion time.

* Execute retention policy after mounting the store protocol
* Start periodic tasks running every 30 min:
	- Retention policy execution  
	- Report stored messages count (just after executing the retention policy)
* Remove waku store `handleMessage()`'s unnecessary async pragma
* Update tests accordingly

As a result, stored messages count **ONLY** will be updated every 30 minutes (after the retention policy is executed).
