### PR TITLE
refactor(wakunode): remove deprecated non-async methods

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -241,7 +241,7 @@ proc publish(c: Chat, line: string) =
             c.node.wakuRlnRelay.lastEpoch = message.proof.epoch
       if not c.node.wakuLightPush.isNil():
         # Attempt lightpush
-        asyncSpawn c.node.lightpush(DefaultTopic, message, handler)
+        asyncSpawn c.node.lightpush2(DefaultTopic, message)
       else:
         asyncSpawn c.node.publish(DefaultTopic, message, handler)
     else:
@@ -270,7 +270,7 @@ proc publish(c: Chat, line: string) =
 
     if not c.node.wakuLightPush.isNil():
       # Attempt lightpush
-      asyncSpawn c.node.lightpush(DefaultTopic, message, handler)
+      asyncSpawn c.node.lightpush2(DefaultTopic, message)
     else:
       asyncSpawn c.node.publish(DefaultTopic, message)
 
@@ -475,7 +475,9 @@ proc processInput(rfd: AsyncFD) {.async.} =
           echo &"{chatLine}"
         info "Hit store handler"
 
-      await node.query(HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: chat.contentTopic)]), storeHandler)
+      let queryRes = await node.query(HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: chat.contentTopic)]))
+      if queryRes.isOk():
+        storeHandler(queryRes.value)
   
   # NOTE Must be mounted after relay
   if conf.lightpushnode != "":

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -12,72 +12,83 @@ import
   ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
+  ../../waku/v2/utils/time,
   ../../waku/v2/node/wakunode2
+
+from std/times import getTime, toUnixFloat
+
+
+const 
+  DefaultPubsubTopic = "/waku/2/default-waku/proto"
+  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
+
+proc now(): Timestamp = 
+  getNanosecondTime(getTime().toUnixFloat())
+
+proc fakeWakuMessage(
+  payload = "TEST-PAYLOAD",
+  contentTopic = DefaultContentTopic, 
+  ts = now()
+): WakuMessage = 
+  WakuMessage(
+    payload: toBytes(payload),
+    contentTopic: contentTopic,
+    version: 1,
+    timestamp: ts
+  )
 
 
 procSuite "WakuNode - Lightpush":
   let rng = crypto.newRng()
  
   asyncTest "Lightpush message return success":
+    ## Setup
     let
-      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60010))
-      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60012))
-      nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60013))
+      lightNodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      lightNode = WakuNode.new(lightNodeKey, ValidIpAddress.init("0.0.0.0"), Port(60010))
+      bridgeNodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      bridgeNode = WakuNode.new(bridgeNodeKey, ValidIpAddress.init("0.0.0.0"), Port(60012))
+      destNodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      destNode = WakuNode.new(destNodeKey, ValidIpAddress.init("0.0.0.0"), Port(60013))
 
-    let
-      pubSubTopic = "test"
-      contentTopic = ContentTopic("/waku/2/default-content/proto")
-      payload = "hello world".toBytes()
-      message = WakuMessage(payload: payload, contentTopic: contentTopic)
+    await allFutures(destNode.start(), bridgeNode.start(), lightNode.start())
 
-    # Light node, only lightpush
-    await node1.start()
-    await node1.mountLightPush()
+    await destNode.mountRelay(@[DefaultPubsubTopic])
+    await bridgeNode.mountRelay(@[DefaultPubsubTopic])
+    await bridgeNode.mountLightPush()
+    await lightNode.mountLightPush()
+    
+    discard await lightNode.peerManager.dialPeer(bridgeNode.peerInfo.toRemotePeerInfo(), WakuLightPushCodec)
+    await sleepAsync(100.milliseconds)
+    await destNode.connectToNodes(@[bridgeNode.peerInfo.toRemotePeerInfo()])
 
-    # Intermediate node
-    await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
-    await node2.mountLightPush()
+    ## Given
+    let message = fakeWakuMessage()
 
-    # Receiving node
-    await node3.start()
-    await node3.mountRelay(@[pubSubTopic])
-
-    discard await node1.peerManager.dialPeer(node2.switch.peerInfo.toRemotePeerInfo(), WakuLightPushCodec)
-    await sleepAsync(1.seconds)
-    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
-
-    var completionFutLightPush = newFuture[bool]()
     var completionFutRelay = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
-      completionFutRelay.complete(true)
-
-    node3.subscribe(pubSubTopic, relayHandler)
-    await sleepAsync(500.millis)
-
-    proc handler(response: PushResponse) {.gcsafe, closure.} =
-      debug "push response handler, expecting true"
+    proc relayHandler(pubsubTopic: string, data: seq[byte]) {.async, gcsafe.} =
+      let msg = WakuMessage.init(data).get()
       check:
-        response.isSuccess == true
-      completionFutLightPush.complete(true)
+        pubsubTopic == DefaultPubsubTopic
+        msg == message
+      completionFutRelay.complete(true)
+    destNode.subscribe(DefaultPubsubTopic, relayHandler)
 
-    # Publishing with lightpush
-    await node1.lightpush(pubSubTopic, message, handler)
-    await sleepAsync(500.millis)
+    # Wait for subscription to take effect
+    await sleepAsync(100.millis)
 
+    ## When
+    let lightpushRes = await lightNode.lightpush(DefaultPubsubTopic, message)
+
+    require (await completionFutRelay.withTimeout(5.seconds)) == true
+    
+    ## Then
+    check lightpushRes.isOk()
+      
+    let response = lightpushRes.get()
     check:
-      (await completionFutRelay.withTimeout(1.seconds)) == true
-      (await completionFutLightPush.withTimeout(1.seconds)) == true
+      response.isSuccess == true
 
-    await allFutures([node1.stop(), node2.stop(), node3.stop()])
+    ## Cleanup
+    await allFutures(lightNode.stop(), bridgeNode.stop(), destNode.stop())
   

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -26,23 +26,20 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     ## Returns history for a list of content topics with optional paging
     debug "get_waku_v2_store_v1_messages"
 
-    var responseFut = newFuture[StoreResponse]()
- 
-    proc queryFuncHandler(response: HistoryResponse) {.gcsafe, closure.} =
-      debug "get_waku_v2_store_v1_messages response"
-      responseFut.complete(response.toStoreResponse())
-    
     let historyQuery = HistoryQuery(pubsubTopic: if pubsubTopicOption.isSome: pubsubTopicOption.get() else: "",
                                     contentFilters: if contentFiltersOption.isSome: contentFiltersOption.get() else: @[],
                                     startTime: if startTime.isSome: startTime.get() else: Timestamp(0),
                                     endTime: if endTime.isSome: endTime.get() else: Timestamp(0),
                                     pagingInfo: if pagingOptions.isSome: pagingOptions.get.toPagingInfo() else: PagingInfo())
-    
-    await node.query(historyQuery, queryFuncHandler)
+    let req = node.query(historyQuery)
 
-    if (await responseFut.withTimeout(futTimeout)):
-      # Future completed
-      return responseFut.read()
-    else:
+    if not (await req.withTimeout(futTimeout)):
       # Future failed to complete
-      raise newException(ValueError, "No history response received")
+      raise newException(ValueError, "No history response received (timeout)")
+    
+    let res = req.read()
+    if res.isErr():
+      raise newException(ValueError, $res.error())
+
+    debug "get_waku_v2_store_v1_messages response"
+    return res.value.toStoreResponse()

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -246,9 +246,6 @@ proc setPeer*(ws: WakuStore, peer: RemotePeerInfo) =
   ws.peerManager.addPeer(peer, WakuStoreCodec)
   waku_store_peers.inc()
 
-# TODO: Remove after converting the query method into a non-callback method
-type QueryHandlerFunc* = proc(response: HistoryResponse) {.gcsafe, closure.}
-
 proc query(w: WakuStore, req: HistoryQuery, peer: RemotePeerInfo): Future[WakuStoreResult[HistoryResponse]] {.async, gcsafe.} =
   let connOpt = await w.peerManager.dialPeer(peer, WakuStoreCodec)
   if connOpt.isNone():


### PR DESCRIPTION
The present PR aims to remove the deprecated non-async methods from `wakunode2` module:

* Remove waku lightpush deprecated method
* Remove waku waku store query deprecated method
* Update tests and examples accordingly
