### PR TITLE
fix: signing key for wakuv2 DNS lists has changed

### DIFF
--- a/docs/operators/droplet-quickstart.md
+++ b/docs/operators/droplet-quickstart.md
@@ -255,8 +255,8 @@ a. Add the parent directory of the wakunode2 binary to your environment:
   ```
 
 b. Choose the fleet you wish to connect your node to:
-  - waku prod: enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im
-  - waku test: enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im
+  - waku prod: enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im
+  - waku test: enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im
 
   ```bash
   export WAKU_FLEET=<fleet>

--- a/docs/operators/how-to/configure-dns-disc.md
+++ b/docs/operators/how-to/configure-dns-disc.md
@@ -24,7 +24,7 @@ A node will attempt connection to all discovered nodes.
 
 This can be used, for example, to connect to one of the existing fleets.
 Current URLs for the published fleet lists:
-- production fleet: `enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im`
-- test fleet: `enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im`
+- production fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im`
+- test fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im`
 
 See the [separate tutorial](../../tutorial/dns-disc.md) for a complete guide to DNS discovery.

--- a/docs/operators/how-to/run.md
+++ b/docs/operators/how-to/run.md
@@ -167,7 +167,7 @@ Discovery v5 will attempt to extract the ENRs of the discovered nodes as bootstr
 ./build/wakunode2 \
   --ports-shift:1 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
   --discv5-discovery:true
 ```
 
@@ -182,7 +182,7 @@ Discovery v5 will attempt to extract the ENRs of the discovered nodes as bootstr
 ./build/wakunode2 \
   --ports-shift:1 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im \
   --discv5-discovery:true
 ```
 
@@ -202,7 +202,7 @@ appears below.
   --db-path:/mnt/nwaku/data/db1/ \
   --store-capacity:150000 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im \
   --discv5-discovery:true
 ```
 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -406,10 +406,10 @@ proc processInput(rfd: AsyncFD) {.async.} =
     echo "Connecting to " & $conf.fleet & " fleet using DNS discovery..."
     
     if conf.fleet == Fleet.test:
-      dnsDiscoveryUrl = some("enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im")
+      dnsDiscoveryUrl = some("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im")
     else:
       # Connect to prod by default
-      dnsDiscoveryUrl = some("enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im")
+      dnsDiscoveryUrl = some("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im")
 
   elif conf.dnsDiscovery and conf.dnsDiscoveryUrl != "":
     # No pre-selected fleet. Discover nodes via DNS using user config

--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -235,8 +235,8 @@ A node will attempt connection to all discovered nodes.
 
 This can be used, for example, to connect to one of the existing fleets.
 Current URLs for the published fleet lists:
-- production fleet: `enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im`
-- test fleet: `enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im`
+- production fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im`
+- test fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im`
 
 See the [separate tutorial](../../docs/tutorial/dns-disc.md) for a complete guide to DNS discovery.
 


### PR DESCRIPTION
The keys used to sign the deployed Merkle tree node lists for `wakuv2.*` fleets have changed. See [this comment](https://github.com/status-im/infra-status/issues/17#issuecomment-1250860524) for more detail.

This PR updates the documentation to reflect the change and fixes the `chat2` application by using the new tree URLs. Since the keys are unlikely to change again (previous deployed ones were experimental, but process has now been formalised), there is no apparent need to automate this update process.