### PR TITLE
chore(rln-relay): specifies the address type for the eth-client-address config parameter

### DIFF
--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -280,7 +280,7 @@ type
       name: "eth-account-privatekey" }: string
     
     rlnRelayEthClientAddress* {.
-      desc: "Ethereum testnet client address e.g., ws://localhost:8540/",
+      desc: "Ethereum testnet client WebSocket address e.g., ws://localhost:8540/",
       defaultValue: "ws://localhost:8540/"
       name: "eth-client-address" }: string
     

--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -280,7 +280,7 @@ type
       name: "eth-account-privatekey" }: string
     
     rlnRelayEthClientAddress* {.
-      desc: "Ethereum testnet client WebSocket address e.g., ws://localhost:8540/",
+      desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",
       defaultValue: "ws://localhost:8540/"
       name: "eth-client-address" }: string
     

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -164,7 +164,7 @@ type
       name: "eth-account-privatekey" }: string
     
     rlnRelayEthClientAddress* {.
-      desc: "Ethereum testnet client WebSocket address e.g., ws://localhost:8540/",
+      desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",
       defaultValue: "ws://localhost:8540/"
       name: "eth-client-address" }: string
     

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -164,7 +164,7 @@ type
       name: "eth-account-privatekey" }: string
     
     rlnRelayEthClientAddress* {.
-      desc: "Ethereum testnet client address e.g., ws://localhost:8540/",
+      desc: "Ethereum testnet client WebSocket address e.g., ws://localhost:8540/",
       defaultValue: "ws://localhost:8540/"
       name: "eth-client-address" }: string
     


### PR DESCRIPTION
Adds a small but important clarification to the description of the `eth-client-address` config option:  the supplied address should be a WebSocket address. 