### PR TITLE
fix(store): move insert criteria logic to waku store protocol module

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -14,6 +14,7 @@ import
   libp2p/protocols/pubsub/rpc/message
 import
   ../../waku/v1/node/rpc/hexstrings,
+  ../../waku/v2/node/storage/message/message_store,
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/node/wakunode2,
   ../../waku/v2/node/jsonrpc/[store_api,
@@ -258,7 +259,7 @@ procSuite "Waku v2 JSON-RPC API":
         WakuMessage(payload: @[byte 9], contentTopic: ContentTopic("2"), timestamp: 9)]
 
     for wakuMsg in msgList:
-      node.wakuStore.handleMessage(defaultTopic, wakuMsg)
+      require node.wakuStore.store.put(defaultTopic, wakuMsg).isOk()
 
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort, false)

--- a/tests/v2/test_message_store_queue.nim
+++ b/tests/v2/test_message_store_queue.nim
@@ -88,34 +88,6 @@ procSuite "Sorted store queue":
     check:
       store.len == capacity
 
-  test "Sender time can't be more than MaxTimeVariance in future":
-    ## Given
-    let capacity = 5
-    let store = StoreQueueRef.new(capacity)
-    let
-      receiverTime = getNanoSecondTime(10)
-      senderTimeOk = receiverTime + StoreMaxTimeVariance
-      senderTimeErr = senderTimeOk + 1
-    
-    let invalidMessage = IndexedWakuMessage(
-      msg: WakuMessage(
-        payload: @[byte 1], 
-        timestamp: senderTimeErr
-      ),
-      index: Index(
-        receiverTime: receiverTime, 
-        senderTime: senderTimeErr
-      )
-    )
-    
-    ## When
-    let addRes = store.add(invalidMessage)
-    
-    ## Then
-    check:
-      addRes.isErr()
-      addRes.error() == "future_sender_timestamp"
-    
   test "Store queue sort-on-insert works":    
     ## Given
     let

--- a/tests/v2/test_message_store_sqlite_query.nim
+++ b/tests/v2/test_message_store_sqlite_query.nim
@@ -59,8 +59,7 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      require store.put(DefaultPubsubTopic, msg).isOk()
     
     ## When
     let res = store.getMessagesByHistoryQuery(
@@ -108,8 +107,7 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      require store.put(DefaultPubsubTopic, msg).isOk()
     
     ## When
     let res = store.getMessagesByHistoryQuery(
@@ -159,8 +157,7 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      require store.put(DefaultPubsubTopic, msg).isOk()
     
     ## When
     let res = store.getMessagesByHistoryQuery(
@@ -203,8 +200,7 @@ suite "message store - history query":
       fakeWakuMessage("MSG-02", contentTopic=contentTopic, ts=getNanosecondTime(epochTime()) + 3),
     ]
     for msg in messages1:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      require store.put(DefaultPubsubTopic, msg).isOk()
       
 
     let messages2 = @[
@@ -214,8 +210,7 @@ suite "message store - history query":
       fakeWakuMessage("MSG-06", contentTopic=contentTopic, ts=getNanosecondTime(epochTime()) + 7),
     ]
     for msg in messages2:
-      let index = Index.compute(msg, msg.timestamp, pubsubTopic)
-      require store.put(index, msg, pubsubTopic).isOk()
+      require store.put(pubsubTopic, msg).isOk()
      
     ## When
     let res = store.getMessagesByHistoryQuery(
@@ -264,8 +259,7 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      require store.put(DefaultPubsubTopic, msg).isOk()
 
     let cursor = Index.compute(messages[4], messages[4].timestamp, DefaultPubsubTopic)
     
@@ -316,8 +310,7 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      require store.put(DefaultPubsubTopic, msg).isOk()
 
     let cursor = Index.compute(messages[6], messages[6].timestamp, DefaultPubsubTopic)
     
@@ -363,8 +356,7 @@ suite "message store - history query":
       fakeWakuMessage("MSG-03", contentTopic=contentTopic, ts=getNanosecondTime(epochTime()) + 4),
     ]
     for msg in messages1:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      require store.put(DefaultPubsubTopic, msg).isOk()
 
     let messages2 = @[
       fakeWakuMessage("MSG-04", contentTopic=contentTopic, ts=getNanosecondTime(epochTime()) + 5),
@@ -372,8 +364,7 @@ suite "message store - history query":
       fakeWakuMessage("MSG-06", contentTopic=contentTopic, ts=getNanosecondTime(epochTime()) + 7),
     ]
     for msg in messages2:
-      let index = Index.compute(msg, msg.timestamp, pubsubTopic)
-      require store.put(index, msg, pubsubTopic).isOk()
+      require store.put(pubsubTopic, msg).isOk()
 
     let cursor = Index.compute(messages2[0], messages2[0].timestamp, DefaultPubsubTopic)
     
@@ -420,8 +411,7 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      require store.put(DefaultPubsubTopic, msg).isOk()
     
     ## When
     let res = store.getMessagesByHistoryQuery(
@@ -462,8 +452,8 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      let digest = computeDigest(msg)
+      require store.put(DefaultPubsubTopic, msg, digest, msg.timestamp).isOk()
     
     ## When
     let res = store.getMessagesByHistoryQuery(
@@ -474,6 +464,7 @@ suite "message store - history query":
       ascendingOrder=true
     )
 
+    ## Then
     check:
       res.isOk()
 
@@ -508,8 +499,8 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      let digest = computeDigest(msg)
+      require store.put(DefaultPubsubTopic, msg, digest, msg.timestamp).isOk()
     
     ## When
     let res = store.getMessagesByHistoryQuery(
@@ -550,8 +541,8 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      let digest = computeDigest(msg)
+      require store.put(DefaultPubsubTopic, msg, digest, msg.timestamp).isOk()
     
     ## When
     let res = store.getMessagesByHistoryQuery(
@@ -596,8 +587,8 @@ suite "message store - history query":
     ]
 
     for msg in messages:
-      let index = Index.compute(msg, msg.timestamp, DefaultPubsubTopic)
-      require store.put(index, msg, DefaultPubsubTopic).isOk()
+      let digest = computeDigest(msg)
+      require store.put(DefaultPubsubTopic, msg, digest, msg.timestamp).isOk()
 
     let cursor = Index.compute(messages[3], messages[3].timestamp, DefaultPubsubTopic)
 

--- a/waku/v2/node/storage/message/message_store.nim
+++ b/waku/v2/node/storage/message/message_store.nim
@@ -4,17 +4,12 @@
 {.push raises: [Defect].}
 
 import
-  std/options,
-  stew/results,
-  chronos
+  std/[options, times],
+  stew/results
 import
   ../../../protocol/waku_message,
   ../../../utils/time,
   ../../../utils/pagination
-
-
-# TODO: Remove this constant after moving time variance checks to waku store protocol
-const StoreMaxTimeVariance* = getNanoSecondTime(20) # 20 seconds maximum allowable sender timestamp "drift" into the future
 
 
 type
@@ -28,7 +23,15 @@ type
 
 
 # MessageStore interface
-method put*(ms: MessageStore, cursor: Index, message: WakuMessage, pubsubTopic: string): MessageStoreResult[void] {.base.} = discard
+method put*(ms: MessageStore, pubsubTopic: string, message: WakuMessage, digest: MessageDigest, receivedTime: Timestamp): MessageStoreResult[void] {.base.} = discard
+
+method put*(ms: MessageStore, pubsubTopic: string, message: WakuMessage): MessageStoreResult[void] =
+  let
+    digest = computeDigest(message) 
+    receivedTime = getNanosecondTime(getTime().toUnixFloat()) 
+  
+  ms.put(pubsubTopic, message, digest, receivedTime)
+
 
 method getAllMessages*(ms: MessageStore): MessageStoreResult[seq[MessageStoreRow]] {.base.} = discard
 

--- a/waku/v2/utils/pagination.nim
+++ b/waku/v2/utils/pagination.nim
@@ -8,6 +8,7 @@ import
   ../protocol/waku_message,
   ./time
 
+type MessageDigest* = MDigest[256]
 
 const
   MaxPageSize*: uint64 = 100
@@ -20,9 +21,9 @@ type Index* = object
   pubsubTopic*: string
   senderTime*: Timestamp # the time at which the message is generated
   receiverTime*: Timestamp
-  digest*: MDigest[256] # calculated over payload and content topic
+  digest*: MessageDigest # calculated over payload and content topic
 
-proc computeDigest*(msg: WakuMessage): MDigest[256] =
+proc computeDigest*(msg: WakuMessage): MessageDigest =
   var ctx: sha256
   ctx.init()
   defer: ctx.clear()


### PR DESCRIPTION
This PR aims to address the inconsistencies based [the discussion](https://github.com/vacp2p/rfc/pull/535#discussion_r973520241) about what should be considered a valid message based on the metadata and the payload.

The gist of the changes:

> As we now have more message store implementations, in this PR, I have changed the `MessageStore` interface dependence on the `Index` type when a message is inserted in the DB (see `message_store`'s interface `put()` API). And moved all the common insertion logic to the waku protocol module.
> 
> Now the messages digest is calculated before inserting it into the store. Calculating a hash is a computational "costly" operation, so the lesser number of times that we compute it, the better.