### PR TITLE
chore(ci): skip test workflow execution for docs changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,15 @@ name: Test
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   test:


### PR DESCRIPTION
Skip tests workflow execution when only doc files (e.g., `README.md`) have been modified