### PR TITLE
fix: fail to start switch with ext ip

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -760,7 +760,10 @@ proc start*(node: WakuNode) {.async.} =
   ##
   ## Status: Implemented.
   
-  # TODO Get this from WakuNode obj
+  ## NB: careful when moving this. We need to start the switch with the bind address
+  ## BEFORE updating with announced addresses for the sake of identify.
+  await node.switch.start()
+  
   let peerInfo = node.switch.peerInfo
   info "PeerInfo", peerId = peerInfo.peerId, addrs = peerInfo.addrs
   var listenStr = ""
@@ -772,14 +775,13 @@ proc start*(node: WakuNode) {.async.} =
   info "Listening on", full = listenStr
   info "DNS: discoverable ENR ", enr = node.enr.toUri()
 
-  ## Update switch peer info with announced addrs
-  node.updateSwitchPeerInfo()
-
   # Perform relay-specific startup tasks TODO: this should be rethought
   if not node.wakuRelay.isNil:
     await node.startRelay()
+  
+  ## Update switch peer info with announced addrs
+  node.updateSwitchPeerInfo()
 
-  await node.switch.start()
   node.started = true
   
   info "Node started successfully"


### PR DESCRIPTION
Fixes regression introduced when submodules were updated.

In order for the node to "advertise" external, announced addresses during the `identify` procedure, the switch's addresses need to be explicitly updated.  However, the switch should be started on the bind address before this is done.

This resulted in `TransportError` being raised when starting the switch with an `extip`.