### PR TITLE
chore(store): collocate pagination and message store types

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -14,7 +14,6 @@ import
   libp2p/protocols/pubsub/rpc/message
 import
   ../../waku/v1/node/rpc/hexstrings,
-  ../../waku/v2/node/storage/message/message_store,
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/node/wakunode2,
   ../../waku/v2/node/jsonrpc/[store_api,

--- a/tests/v2/test_message_store_queue.nim
+++ b/tests/v2/test_message_store_queue.nim
@@ -6,12 +6,10 @@ import
   testutils/unittests,
   nimcrypto/hash
 import
-  ../../waku/v2/node/storage/message/message_store,
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store,
-  ../../waku/v2/utils/time,
-  ../../waku/v2/utils/pagination
+  ../../waku/v2/utils/time
 
 
 # Helper functions

--- a/tests/v2/test_message_store_queue_pagination.nim
+++ b/tests/v2/test_message_store_queue_pagination.nim
@@ -9,8 +9,7 @@ import
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/utils/time,
-  ../../waku/v2/utils/pagination
+  ../../waku/v2/utils/time
 
 
 const 

--- a/tests/v2/test_message_store_sqlite.nim
+++ b/tests/v2/test_message_store_sqlite.nim
@@ -12,8 +12,8 @@ import
   ../../waku/v2/node/storage/message/message_retention_policy_capacity,
   ../../waku/v2/node/storage/sqlite,
   ../../waku/v2/protocol/waku_message,
+  ../../waku/v2/protocol/waku_store/pagination,
   ../../waku/v2/utils/time,
-  ../../waku/v2/utils/pagination,
   ./utils
 
 

--- a/tests/v2/test_message_store_sqlite_query.nim
+++ b/tests/v2/test_message_store_sqlite_query.nim
@@ -9,8 +9,8 @@ import
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/storage/sqlite,
   ../../waku/v2/protocol/waku_message,
+  ../../waku/v2/protocol/waku_store/pagination,
   ../../waku/v2/utils/time,
-  ../../waku/v2/utils/pagination,
   ./utils
 
 

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -12,11 +12,9 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/node/storage/sqlite,
-  ../../waku/v2/node/storage/message/message_store,
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/peer_manager/peer_manager,
-  ../../waku/v2/utils/pagination,
   ../../waku/v2/utils/time,
   ../test_helpers 
 

--- a/tests/v2/test_waku_store_rpc_codec.nim
+++ b/tests/v2/test_waku_store_rpc_codec.nim
@@ -9,7 +9,6 @@ import
 import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store,
-  ../../waku/v2/utils/pagination,
   ../../waku/v2/utils/time
 
 const 

--- a/tests/v2/test_wakunode_store.nim
+++ b/tests/v2/test_wakunode_store.nim
@@ -15,7 +15,6 @@ import
   libp2p/protocols/pubsub/gossipsub
 import
   ../../waku/v2/node/storage/sqlite,
-  ../../waku/v2/node/storage/message/message_store,
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/protocol/waku_message,
@@ -23,7 +22,6 @@ import
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
-  ../../waku/v2/utils/pagination,
   ../../waku/v2/utils/time,
   ../../waku/v2/node/wakunode2
 

--- a/waku/v2/node/jsonrpc/jsonrpc_types.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_types.nim
@@ -4,7 +4,7 @@ import
   std/[options,tables],
   eth/keys,
   ../../protocol/waku_message,
-  ../../utils/pagination,
+  ../../protocol/waku_store/pagination,
   ../../utils/time
 
 type

--- a/waku/v2/node/jsonrpc/jsonrpc_utils.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_utils.nim
@@ -4,10 +4,9 @@ import
   std/[options, json],
   eth/keys,
   ../../../v1/node/rpc/hexstrings,
-  ../../protocol/waku_store,
   ../../protocol/waku_message,
+  ../../protocol/waku_store,
   ../../utils/time,
-  ../../utils/pagination,
   ../waku_payload,
   ./jsonrpc_types
 

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -8,7 +8,6 @@ import
   ../wakunode2,
   ../../protocol/waku_store,
   ../../utils/time,
-  ../../utils/pagination,
   ./jsonrpc_types, 
   ./jsonrpc_utils
 

--- a/waku/v2/node/storage/message/dual_message_store.nim
+++ b/waku/v2/node/storage/message/dual_message_store.nim
@@ -6,10 +6,10 @@ import
   chronicles
 import
   ../../../protocol/waku_message,
-  ../../../utils/pagination,
+  ../../../protocol/waku_store/pagination,
+  ../../../protocol/waku_store/message_store,
   ../../../utils/time,
   ../sqlite,
-  ./message_store,
   ./waku_store_queue,
   ./sqlite_store
 

--- a/waku/v2/node/storage/message/message_retention_policy.nim
+++ b/waku/v2/node/storage/message/message_retention_policy.nim
@@ -3,7 +3,7 @@
 import
   stew/results
 import
-  ./message_store
+  ../../../protocol/waku_store/message_store
 
 type RetentionPolicyResult*[T] = Result[T, string]
 

--- a/waku/v2/node/storage/message/message_retention_policy_capacity.nim
+++ b/waku/v2/node/storage/message/message_retention_policy_capacity.nim
@@ -4,7 +4,7 @@ import
   stew/results,
   chronicles
 import
-  ./message_store,
+  ../../../protocol/waku_store/message_store,
   ./message_retention_policy
 
 logScope:

--- a/waku/v2/node/storage/message/message_retention_policy_time.nim
+++ b/waku/v2/node/storage/message/message_retention_policy_time.nim
@@ -6,8 +6,8 @@ import
   chronicles,
   chronos
 import
+  ../../../protocol/waku_store/message_store,
   ../../../utils/time,
-  ./message_store,
   ./message_retention_policy
 
 logScope:

--- a/waku/v2/node/storage/message/queue_store/index.nim
+++ b/waku/v2/node/storage/message/queue_store/index.nim
@@ -5,8 +5,8 @@ import
   nimcrypto/sha2
 import
   ../../../../protocol/waku_message,
-  ../../../../utils/time,
-  ../../../../utils/pagination
+  ../../../../protocol/waku_store/pagination,
+  ../../../../utils/time
 
 
 type Index* = object

--- a/waku/v2/node/storage/message/queue_store/queue_store.nim
+++ b/waku/v2/node/storage/message/queue_store/queue_store.nim
@@ -7,9 +7,9 @@ import
 import
   ../../../../protocol/waku_message,
   ../../../../protocol/waku_store/rpc,
-  ../../../../utils/pagination,
+  ../../../../protocol/waku_store/pagination,
+  ../../../../protocol/waku_store/message_store,
   ../../../../utils/time,
-  ../message_store,
   ./index
 
 

--- a/waku/v2/node/storage/message/sqlite_store/queries.nim
+++ b/waku/v2/node/storage/message/sqlite_store/queries.nim
@@ -7,7 +7,7 @@ import
 import
   ../../sqlite, 
   ../../../../protocol/waku_message,
-  ../../../../utils/pagination,
+  ../../../../protocol/waku_store/pagination,
   ../../../../utils/time
 
 

--- a/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
+++ b/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
@@ -8,10 +8,10 @@ import
   chronicles
 import
   ../../../../protocol/waku_message,
-  ../../../../utils/pagination,
+  ../../../../protocol/waku_store/pagination,
+  ../../../../protocol/waku_store/message_store,
   ../../../../utils/time,
   ../../sqlite,
-  ../message_store,
   ./queries
 
 logScope:

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -25,7 +25,6 @@ import
   ../utils/[peers, requests, wakuenr],
   ./peer_manager/peer_manager,
   ./storage/message/waku_store_queue,
-  ./storage/message/message_store,
   ./storage/message/message_retention_policy,
   ./storage/message/message_retention_policy_capacity,
   ./storage/message/message_retention_policy_time,
@@ -819,7 +818,6 @@ when isMainModule:
     ./wakunode2_setup_rpc,
     ./wakunode2_setup_sql_migrations,
     ./storage/sqlite,
-    ./storage/message/message_store,
     ./storage/message/dual_message_store,
     ./storage/message/sqlite_store,
     ./storage/peer/waku_peer_storage

--- a/waku/v2/protocol/waku_store.nim
+++ b/waku/v2/protocol/waku_store.nim
@@ -1,9 +1,13 @@
 import
   ./waku_store/protocol,
   ./waku_store/rpc,
-  ./waku_store/rpc_codec
+  ./waku_store/rpc_codec,
+  ./waku_store/pagination,
+  ./waku_store/message_store
 
 export
   protocol,
   rpc,
-  rpc_codec
+  rpc_codec, 
+  pagination,
+  message_store

--- a/waku/v2/protocol/waku_store/message_store.nim
+++ b/waku/v2/protocol/waku_store/message_store.nim
@@ -7,9 +7,9 @@ import
   std/[options, times],
   stew/results
 import
-  ../../../protocol/waku_message,
-  ../../../utils/time,
-  ../../../utils/pagination
+  ../waku_message,
+  ./pagination,
+  ../../utils/time
 
 
 type

--- a/waku/v2/protocol/waku_store/pagination.nim
+++ b/waku/v2/protocol/waku_store/pagination.nim
@@ -5,8 +5,8 @@ import
   stew/byteutils,
   nimcrypto/sha2
 import
-  ../protocol/waku_message,
-  ./time
+  ../waku_message,
+  ../../utils/time
 
 const
   MaxPageSize*: uint64 = 100

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -15,17 +15,17 @@ import
   libp2p/stream/connection,
   metrics
 import
-  ../../node/storage/message/message_store,
   ../../node/storage/message/message_retention_policy,
   ../../node/storage/message/waku_store_queue,
   ../../node/peer_manager/peer_manager,
   ../../utils/time,
-  ../../utils/pagination,
   ../../utils/requests,
   ../waku_message,
   ../waku_swap/waku_swap,
   ./rpc,
-  ./rpc_codec
+  ./rpc_codec,
+  ./pagination,
+  ./message_store
 
 
 declarePublicGauge waku_store_messages, "number of historical messages", ["type"]

--- a/waku/v2/protocol/waku_store/rpc.nim
+++ b/waku/v2/protocol/waku_store/rpc.nim
@@ -4,8 +4,8 @@ import
   nimcrypto/hash
 import
   ../waku_message,
-  ../../utils/pagination,
-  ../../utils/time
+  ../../utils/time,
+  ./pagination
 
 
 type

--- a/waku/v2/protocol/waku_store/rpc_codec.nim
+++ b/waku/v2/protocol/waku_store/rpc_codec.nim
@@ -7,9 +7,9 @@ import
 import
   ../waku_message,
   ../../utils/protobuf,
-  ../../utils/pagination,
   ../../utils/time,
-  ./rpc
+  ./rpc,
+  ./pagination
 
 
 const MaxRpcSize* = MaxPageSize * MaxWakuMessageSize + 64*1024 # We add a 64kB safety buffer for protocol overhead


### PR DESCRIPTION
This is a code reorganization PR to clear out the imports graph:

* Move pagination from utils to waku store protocol module
* Move message store interface module to waku store protocol module

The files are collocated with the waku protocol, so now the dependency graph is:

> Message Store Impl -> Waku Store Protocol
> Waku Node -> Waku Store Protocol

instead of:

> Waku Store Protocol -> Message Store Impl (module)
> Waku Node -> Waku Store Protocol
> Waku Node -> Message Store Impl