### PR TITLE
Makefile: allow overriding GIT_VERSION with env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ endif
 NIM_PARAMS := $(NIM_PARAMS) -d:discv5_protocol_id:d5waku
 
 # git version for JSON RPC call
-GIT_VERSION := "$(shell git describe --abbrev=6 --always --tags)"
+GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
 NIM_PARAMS := $(NIM_PARAMS) -d:git_version:\"$(GIT_VERSION)\"
 
 deps: | deps-common nat-libs waku.nims rlnlib rlnzerokitlib


### PR DESCRIPTION
This is necessary for Nix builds because the sandbox there does not contain `.git` directory or `git` command.

Also the quotes are pointless.