### PR TITLE
chore(rln-relay): namespaced flags

### DIFF
--- a/docs/tutorial/onchain-rln-relay-chat2.md
+++ b/docs/tutorial/onchain-rln-relay-chat2.md
@@ -49,7 +49,7 @@ make chat2 RLN=true
 Run the following command to set up your chat2 client. 
 
 ```
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-account-privatekey:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-client-address:xxxx --ports-shift=1 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-account-private-key:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-client-address:xxxx --ports-shift=1 
 ```
 
 In this command
@@ -60,14 +60,14 @@ In this command
 - the `--rln-relay-eth-contract-address` option gets the address of the membership contract.
  The current address of the contract is `0x4252105670fe33d2947e8ead304969849e64f2a6`.
  You may check the state of the contract on the [Goerli testnet](https://goerli.etherscan.io/address/0x4252105670fe33d2947e8ead304969849e64f2a6).
-- the `rln-relay-eth-account-address` option is for your account address on the Goerli testnet.
+- the `rln-relay-eth-account` option is for your account address on the Goerli testnet.
  It is a hex string of length 40 (not sensitive to the `0x` prefix). 
-- the `rln-relay-eth-account-privatekey` option is for your account private key on the Goerli testnet. 
+- the `rln-relay-eth-account-private-key` option is for your account private key on the Goerli testnet. 
  It is made up of 64 hex characters (not sensitive to the `0x` prefix).
 - the `rln-relay-eth-client-address` is the WebSocket address of the hosted node on the Goerli testnet. 
  You need to replace the `xxxx` with the actual node's address.
 
-For the last three config options i.e., `rln-relay-eth-account-address`, `rln-relay-eth-account-privatekey`, and `rln-relay-eth-client-address`, if you do not know how to obtain those, you may use the following tutorial on the [prerequisites of running on-chain spam-protected chat2](./pre-requisites-of-running-on-chain-spam-protected-chat2.md).
+For the last three config options i.e., `rln-relay-eth-account`, `rln-relay-eth-account-private-key`, and `rln-relay-eth-client-address`, if you do not know how to obtain those, you may use the following tutorial on the [prerequisites of running on-chain spam-protected chat2](./pre-requisites-of-running-on-chain-spam-protected-chat2.md).
 
 You may set up more than one chat client,
 just make sure that you increment the `--ports-shift` value for each new client you set up e.g., `--ports-shift=2`.
@@ -167,12 +167,12 @@ If this file does not already exist under the supplied path, then a new credenti
 Otherwise, the chat client does not generate a new credential and will use, instead, the persisted RLN credential.
 
 ```
-./build/chat2  --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6  --rln-relay-eth-account-address:your_eth_account --rln-relay-eth-account-privatekey:your_eth_private_key  --rln-relay-eth-client-address:your_goerli_node  --ports-shift=1  --rln-relay-cred-path:./
+./build/chat2  --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6  --rln-relay-eth-account:your_eth_account --rln-relay-eth-account-private-key:your_eth_private_key  --rln-relay-eth-client-address:your_goerli_node  --ports-shift=1  --rln-relay-cred-path:./
 ```
 
 # Sample test output
 In this section, a sample test of running two chat clients is provided.
-Note that the values used for `rln-relay-eth-account-address`, `rln-relay-eth-account-privatekey`, and `rln-relay-eth-client-address` in the following code snippets are junk and not valid.
+Note that the values used for `rln-relay-eth-account`, `rln-relay-eth-account-private-key`, and `rln-relay-eth-client-address` in the following code snippets are junk and not valid.
 
 The two chat clients namely `Alice` and `Bob` are connected to the test fleets.
 `Alice` sends 4 messages i.e., `message1`, `message2`, `message3`, and `message4`.
@@ -184,7 +184,7 @@ You can check this fact by looking at `Bob`'s console, where `message3` is missi
 
 **Alice**
 ``` 
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=1 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-private-key:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=1 
 
 Choose a nickname >> Alice
 Welcome, Alice!
@@ -226,7 +226,7 @@ your rln identity commitment key is: bd093cbf14fb933d53f596c33f98b3df83b7e9f7a19
 
 **Bob**
 ``` 
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=2 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-private-key:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=2 
 
 Choose a nickname >> Bob
 Welcome, Bob!

--- a/docs/tutorial/onchain-rln-relay-chat2.md
+++ b/docs/tutorial/onchain-rln-relay-chat2.md
@@ -49,7 +49,7 @@ make chat2 RLN=true
 Run the following command to set up your chat2 client. 
 
 ```
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --eth-mem-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --eth-account-address:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --eth-account-privatekey:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --eth-client-address:xxxx --ports-shift=1 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-membership-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-account-privatekey:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-client-address:xxxx --ports-shift=1 
 ```
 
 In this command
@@ -57,17 +57,17 @@ In this command
 - the `toy-chat/2/luzhou/proto` passed to the `content-topic` option indicates the content topic on which the chat2 application is going to run.
 - the `rln-relay` flag is set to `true` to enable the Waku-RLN-Relay protocol for spam protection.
 - the `--rln-relay-dynamic` flag is set to `true` to enable the on-chain mode of Waku-RLN-Relay protocol with dynamic group management.
-- the `--eth-mem-contract-address` option gets the address of the membership contract.
+- the `--rln-relay-eth-membership-contract-address` option gets the address of the membership contract.
  The current address of the contract is `0x4252105670fe33d2947e8ead304969849e64f2a6`.
  You may check the state of the contract on the [Goerli testnet](https://goerli.etherscan.io/address/0x4252105670fe33d2947e8ead304969849e64f2a6).
-- the `eth-account-address` option is for your account address on the Goerli testnet.
+- the `rln-relay-eth-account-address` option is for your account address on the Goerli testnet.
  It is a hex string of length 40 (not sensitive to the `0x` prefix). 
-- the `eth-account-privatekey` option is for your account private key on the Goerli testnet. 
+- the `rln-relay-eth-account-privatekey` option is for your account private key on the Goerli testnet. 
  It is made up of 64 hex characters (not sensitive to the `0x` prefix).
-- the `eth-client-address` is the WebSocket address of the hosted node on the Goerli testnet. 
+- the `rln-relay-eth-client-address` is the WebSocket address of the hosted node on the Goerli testnet. 
  You need to replace the `xxxx` with the actual node's address.
 
-For the last three config options i.e., `eth-account-address`, `eth-account-privatekey`, and `eth-client-address`, if you do not know how to obtain those, you may use the following tutorial on the [prerequisites of running on-chain spam-protected chat2](./pre-requisites-of-running-on-chain-spam-protected-chat2.md).
+For the last three config options i.e., `rln-relay-eth-account-address`, `rln-relay-eth-account-privatekey`, and `rln-relay-eth-client-address`, if you do not know how to obtain those, you may use the following tutorial on the [prerequisites of running on-chain spam-protected chat2](./pre-requisites-of-running-on-chain-spam-protected-chat2.md).
 
 You may set up more than one chat client,
 just make sure that you increment the `--ports-shift` value for each new client you set up e.g., `--ports-shift=2`.
@@ -167,12 +167,12 @@ If this file does not already exist under the supplied path, then a new credenti
 Otherwise, the chat client does not generate a new credential and will use, instead, the persisted RLN credential.
 
 ```
-./build/chat2  --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --eth-mem-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6  --eth-account-address:your_eth_account --eth-account-privatekey:your_eth_private_key  --eth-client-address:your_goerli_node  --ports-shift=1  --rln-relay-cred-path:./
+./build/chat2  --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-membership-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6  --rln-relay-eth-account-address:your_eth_account --rln-relay-eth-account-privatekey:your_eth_private_key  --rln-relay-eth-client-address:your_goerli_node  --ports-shift=1  --rln-relay-cred-path:./
 ```
 
 # Sample test output
 In this section, a sample test of running two chat clients is provided.
-Note that the values used for `eth-account-address`, `eth-account-privatekey`, and `eth-client-address` in the following code snippets are junk and not valid.
+Note that the values used for `rln-relay-eth-account-address`, `rln-relay-eth-account-privatekey`, and `rln-relay-eth-client-address` in the following code snippets are junk and not valid.
 
 The two chat clients namely `Alice` and `Bob` are connected to the test fleets.
 `Alice` sends 4 messages i.e., `message1`, `message2`, `message3`, and `message4`.
@@ -184,7 +184,7 @@ You can check this fact by looking at `Bob`'s console, where `message3` is missi
 
 **Alice**
 ``` 
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --eth-mem-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --eth-account-address:0x1234567890123456789012345678901234567890 --eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=1 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-membership-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=1 
 
 Choose a nickname >> Alice
 Welcome, Alice!
@@ -226,7 +226,7 @@ your rln identity commitment key is: bd093cbf14fb933d53f596c33f98b3df83b7e9f7a19
 
 **Bob**
 ``` 
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --eth-mem-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --eth-account-address:0x1234567890123456789012345678901234567890 --eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=2 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-membership-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=2 
 
 Choose a nickname >> Bob
 Welcome, Bob!

--- a/docs/tutorial/onchain-rln-relay-chat2.md
+++ b/docs/tutorial/onchain-rln-relay-chat2.md
@@ -49,7 +49,7 @@ make chat2 RLN=true
 Run the following command to set up your chat2 client. 
 
 ```
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-account-private-key:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-client-address:xxxx --ports-shift=1 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-account-private-key:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-client-address:xxxx --ports-shift=1 
 ```
 
 In this command
@@ -60,14 +60,14 @@ In this command
 - the `--rln-relay-eth-contract-address` option gets the address of the membership contract.
  The current address of the contract is `0x4252105670fe33d2947e8ead304969849e64f2a6`.
  You may check the state of the contract on the [Goerli testnet](https://goerli.etherscan.io/address/0x4252105670fe33d2947e8ead304969849e64f2a6).
-- the `rln-relay-eth-account` option is for your account address on the Goerli testnet.
+- the `rln-relay-eth-account-address` option is for your account address on the Goerli testnet.
  It is a hex string of length 40 (not sensitive to the `0x` prefix). 
 - the `rln-relay-eth-account-private-key` option is for your account private key on the Goerli testnet. 
  It is made up of 64 hex characters (not sensitive to the `0x` prefix).
 - the `rln-relay-eth-client-address` is the WebSocket address of the hosted node on the Goerli testnet. 
  You need to replace the `xxxx` with the actual node's address.
 
-For the last three config options i.e., `rln-relay-eth-account`, `rln-relay-eth-account-private-key`, and `rln-relay-eth-client-address`, if you do not know how to obtain those, you may use the following tutorial on the [prerequisites of running on-chain spam-protected chat2](./pre-requisites-of-running-on-chain-spam-protected-chat2.md).
+For the last three config options i.e., `rln-relay-eth-account-address`, `rln-relay-eth-account-private-key`, and `rln-relay-eth-client-address`, if you do not know how to obtain those, you may use the following tutorial on the [prerequisites of running on-chain spam-protected chat2](./pre-requisites-of-running-on-chain-spam-protected-chat2.md).
 
 You may set up more than one chat client,
 just make sure that you increment the `--ports-shift` value for each new client you set up e.g., `--ports-shift=2`.
@@ -167,12 +167,12 @@ If this file does not already exist under the supplied path, then a new credenti
 Otherwise, the chat client does not generate a new credential and will use, instead, the persisted RLN credential.
 
 ```
-./build/chat2  --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6  --rln-relay-eth-account:your_eth_account --rln-relay-eth-account-private-key:your_eth_private_key  --rln-relay-eth-client-address:your_goerli_node  --ports-shift=1  --rln-relay-cred-path:./
+./build/chat2  --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6  --rln-relay-eth-account-address:your_eth_account --rln-relay-eth-account-private-key:your_eth_private_key  --rln-relay-eth-client-address:your_goerli_node  --ports-shift=1  --rln-relay-cred-path:./
 ```
 
 # Sample test output
 In this section, a sample test of running two chat clients is provided.
-Note that the values used for `rln-relay-eth-account`, `rln-relay-eth-account-private-key`, and `rln-relay-eth-client-address` in the following code snippets are junk and not valid.
+Note that the values used for `rln-relay-eth-account-address`, `rln-relay-eth-account-private-key`, and `rln-relay-eth-client-address` in the following code snippets are junk and not valid.
 
 The two chat clients namely `Alice` and `Bob` are connected to the test fleets.
 `Alice` sends 4 messages i.e., `message1`, `message2`, `message3`, and `message4`.
@@ -184,7 +184,7 @@ You can check this fact by looking at `Bob`'s console, where `message3` is missi
 
 **Alice**
 ``` 
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-private-key:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=1 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-private-key:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=1 
 
 Choose a nickname >> Alice
 Welcome, Alice!
@@ -226,7 +226,7 @@ your rln identity commitment key is: bd093cbf14fb933d53f596c33f98b3df83b7e9f7a19
 
 **Bob**
 ``` 
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-private-key:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=2 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-private-key:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=2 
 
 Choose a nickname >> Bob
 Welcome, Bob!

--- a/docs/tutorial/onchain-rln-relay-chat2.md
+++ b/docs/tutorial/onchain-rln-relay-chat2.md
@@ -49,7 +49,7 @@ make chat2 RLN=true
 Run the following command to set up your chat2 client. 
 
 ```
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-membership-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-account-privatekey:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-client-address:xxxx --ports-shift=1 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-account-privatekey:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --rln-relay-eth-client-address:xxxx --ports-shift=1 
 ```
 
 In this command
@@ -57,7 +57,7 @@ In this command
 - the `toy-chat/2/luzhou/proto` passed to the `content-topic` option indicates the content topic on which the chat2 application is going to run.
 - the `rln-relay` flag is set to `true` to enable the Waku-RLN-Relay protocol for spam protection.
 - the `--rln-relay-dynamic` flag is set to `true` to enable the on-chain mode of Waku-RLN-Relay protocol with dynamic group management.
-- the `--rln-relay-eth-membership-contract-address` option gets the address of the membership contract.
+- the `--rln-relay-eth-contract-address` option gets the address of the membership contract.
  The current address of the contract is `0x4252105670fe33d2947e8ead304969849e64f2a6`.
  You may check the state of the contract on the [Goerli testnet](https://goerli.etherscan.io/address/0x4252105670fe33d2947e8ead304969849e64f2a6).
 - the `rln-relay-eth-account-address` option is for your account address on the Goerli testnet.
@@ -167,7 +167,7 @@ If this file does not already exist under the supplied path, then a new credenti
 Otherwise, the chat client does not generate a new credential and will use, instead, the persisted RLN credential.
 
 ```
-./build/chat2  --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-membership-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6  --rln-relay-eth-account-address:your_eth_account --rln-relay-eth-account-privatekey:your_eth_private_key  --rln-relay-eth-client-address:your_goerli_node  --ports-shift=1  --rln-relay-cred-path:./
+./build/chat2  --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6  --rln-relay-eth-account-address:your_eth_account --rln-relay-eth-account-privatekey:your_eth_private_key  --rln-relay-eth-client-address:your_goerli_node  --ports-shift=1  --rln-relay-cred-path:./
 ```
 
 # Sample test output
@@ -184,7 +184,7 @@ You can check this fact by looking at `Bob`'s console, where `message3` is missi
 
 **Alice**
 ``` 
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-membership-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=1 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=1 
 
 Choose a nickname >> Alice
 Welcome, Alice!
@@ -226,7 +226,7 @@ your rln identity commitment key is: bd093cbf14fb933d53f596c33f98b3df83b7e9f7a19
 
 **Bob**
 ``` 
-./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-membership-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=2 
+./build/chat2 --fleet:test --content-topic:/toy-chat/2/luzhou/proto --rln-relay:true --rln-relay-dynamic:true --rln-relay-eth-contract-address:0x4252105670fe33d2947e8ead304969849e64f2a6 --rln-relay-eth-account-address:0x1234567890123456789012345678901234567890 --rln-relay-eth-account-privatekey:0x1234567890123456789012345678901234567890123456789012345678901234 --rln-relay-eth-client-address:wss://goerli.infura.io/ws/v3/12345678901234567890123456789012 --ports-shift=2 
 
 Choose a nickname >> Bob
 Welcome, Bob!

--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -269,11 +269,11 @@ type
       defaultValue: ""
       name: "rln-relay-id-commitment" }: string
   
-    rlnRelayEthAccount* {.
+    rlnRelayEthAccountAddress* {.
       desc: "Ethereum account address for an Ethereum testnet",
       # NOTE: This can be derived from the private key, but kept for future use
       defaultValue: ""
-      name: "rln-relay-eth-account" }: string
+      name: "rln-relay-eth-account-address" }: string
     
     rlnRelayEthAccountPrivateKey* {.
       desc: "Account private key for an Ethereum testnet",

--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -273,12 +273,12 @@ type
       desc: "Ethereum account address for an Ethereum testnet",
       # NOTE: This can be derived from the private key, but kept for future use
       defaultValue: ""
-      name: "rln-relay-eth-account-address" }: string
+      name: "rln-relay-eth-account" }: string
     
-    rlnRelayEthAccountPrivKey* {.
+    rlnRelayEthAccountPrivateKey* {.
       desc: "Account private key for an Ethereum testnet",
       defaultValue: ""
-      name: "rln-relay-eth-account-privatekey" }: string
+      name: "rln-relay-eth-account-private-key" }: string
     
     rlnRelayEthClientAddress* {.
       desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",

--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -285,10 +285,10 @@ type
       defaultValue: "ws://localhost:8540/"
       name: "rln-relay-eth-client-address" }: string
     
-    rlnRelayEthMemContractAddress* {.
+    rlnRelayEthContractAddress* {.
       desc: "Address of membership contract on an Ethereum testnet", 
       defaultValue: ""
-      name: "rln-relay-eth-membership-contract-address" }: string
+      name: "rln-relay-eth-contract-address" }: string
     
 # NOTE: Keys are different in nim-libp2p
 proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =

--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -270,24 +270,25 @@ type
       name: "rln-relay-id-commitment" }: string
   
     rlnRelayEthAccount* {.
-      desc: "Ethereum account address for an Ethereum testnet", 
+      desc: "Ethereum account address for an Ethereum testnet",
+      # NOTE: This can be derived from the private key, but kept for future use
       defaultValue: ""
-      name: "eth-account-address" }: string
+      name: "rln-relay-eth-account-address" }: string
     
     rlnRelayEthAccountPrivKey* {.
       desc: "Account private key for an Ethereum testnet",
       defaultValue: ""
-      name: "eth-account-privatekey" }: string
+      name: "rln-relay-eth-account-privatekey" }: string
     
     rlnRelayEthClientAddress* {.
       desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",
       defaultValue: "ws://localhost:8540/"
-      name: "eth-client-address" }: string
+      name: "rln-relay-eth-client-address" }: string
     
     rlnRelayEthMemContractAddress* {.
       desc: "Address of membership contract on an Ethereum testnet", 
       defaultValue: ""
-      name: "eth-mem-contract-address" }: string
+      name: "rln-relay-eth-membership-contract-address" }: string
     
 # NOTE: Keys are different in nim-libp2p
 proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =

--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -239,7 +239,7 @@ type
       defaultValue: ""
       name: "rln-relay-cred-path" }: string
    
-    rlnRelayMemIndex* {.
+    rlnRelayMembershipIndex* {.
       desc: "(experimental) the index of node in the rln-relay group: a value between 0-99 inclusive",
       defaultValue: 0
       name: "rln-relay-membership-index" }: uint
@@ -262,12 +262,12 @@ type
     rlnRelayIdKey* {.
       desc: "Rln relay identity secret key as a Hex string", 
       defaultValue: ""
-      name: "rln-relay-id" }: string
+      name: "rln-relay-id-key" }: string
     
     rlnRelayIdCommitmentKey* {.
       desc: "Rln relay identity commitment key as a Hex string", 
       defaultValue: ""
-      name: "rln-relay-id-commitment" }: string
+      name: "rln-relay-id-commitment-key" }: string
   
     rlnRelayEthAccountAddress* {.
       desc: "Ethereum account address for an Ethereum testnet",

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -157,12 +157,12 @@ type
       desc: "Account address for the Ethereum testnet Goerli", 
       # NOTE: This can be derived from the private key, but kept for future use
       defaultValue: ""
-      name: "rln-relay-eth-account-address" }: string
+      name: "rln-relay-eth-account" }: string
 
-    rlnRelayEthAccountPrivKey* {.
+    rlnRelayEthAccountPrivateKey* {.
       desc: "Account private key for the Ethereum testnet Goerli",
       defaultValue: ""
-      name: "rln-relay-eth-account-privatekey" }: string
+      name: "rln-relay-eth-account-private-key" }: string
     
     rlnRelayEthClientAddress* {.
       desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -169,10 +169,10 @@ type
       defaultValue: "ws://localhost:8540/"
       name: "rln-relay-eth-client-address" }: string
     
-    rlnRelayEthMemContractAddress* {.
+    rlnRelayEthContractAddress* {.
       desc: "Address of membership contract on an Ethereum testnet", 
       defaultValue: ""
-      name: "rln-relay-eth-membership-contract-address" }: string
+      name: "rln-relay-eth-contract-address" }: string
     
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -153,11 +153,11 @@ type
       defaultValue: ""
       name: "rln-relay-id-commitment" }: string
   
-    rlnRelayEthAccount* {.
+    rlnRelayEthAccountAddress* {.
       desc: "Account address for the Ethereum testnet Goerli", 
       # NOTE: This can be derived from the private key, but kept for future use
       defaultValue: ""
-      name: "rln-relay-eth-account" }: string
+      name: "rln-relay-eth-account-address" }: string
 
     rlnRelayEthAccountPrivateKey* {.
       desc: "Account private key for the Ethereum testnet Goerli",

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -123,7 +123,7 @@ type
       defaultValue: ""
       name: "rln-relay-cred-path" }: string
 
-    rlnRelayMemIndex* {.
+    rlnRelayMembershipIndex* {.
       desc: "(experimental) the index of node in the rln-relay group: a value between 0-99 inclusive",
       defaultValue: 0
       name: "rln-relay-membership-index" }: uint
@@ -146,12 +146,12 @@ type
     rlnRelayIdKey* {.
       desc: "Rln relay identity secret key as a Hex string", 
       defaultValue: ""
-      name: "rln-relay-id" }: string
+      name: "rln-relay-id-key" }: string
     
     rlnRelayIdCommitmentKey* {.
       desc: "Rln relay identity commitment key as a Hex string", 
       defaultValue: ""
-      name: "rln-relay-id-commitment" }: string
+      name: "rln-relay-id-commitment-key" }: string
   
     rlnRelayEthAccountAddress* {.
       desc: "Account address for the Ethereum testnet Goerli", 

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -155,23 +155,24 @@ type
   
     rlnRelayEthAccount* {.
       desc: "Account address for the Ethereum testnet Goerli", 
+      # NOTE: This can be derived from the private key, but kept for future use
       defaultValue: ""
-      name: "eth-account-address" }: string
+      name: "rln-relay-eth-account-address" }: string
 
     rlnRelayEthAccountPrivKey* {.
       desc: "Account private key for the Ethereum testnet Goerli",
       defaultValue: ""
-      name: "eth-account-privatekey" }: string
+      name: "rln-relay-eth-account-privatekey" }: string
     
     rlnRelayEthClientAddress* {.
       desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",
       defaultValue: "ws://localhost:8540/"
-      name: "eth-client-address" }: string
+      name: "rln-relay-eth-client-address" }: string
     
     rlnRelayEthMemContractAddress* {.
       desc: "Address of membership contract on an Ethereum testnet", 
       defaultValue: ""
-      name: "eth-mem-contract-address" }: string
+      name: "rln-relay-eth-membership-contract-address" }: string
     
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1162,7 +1162,7 @@ proc mount(node: WakuNode,
     
     # read related inputs to run rln-relay in on-chain mode and do type conversion when needed
     let 
-      ethAccountAddr = web3.fromHex(web3.Address, conf.rlnRelayEthAccount)
+      ethAccountAddr = web3.fromHex(web3.Address, conf.rlnRelayEthAccountAddress)
       ethClientAddr = conf.rlnRelayEthClientAddress
       ethMemContractAddress = web3.fromHex(web3.Address, conf.rlnRelayEthContractAddress)
     var ethAccountPrivKeyOpt = none(keys.PrivateKey)

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -653,7 +653,7 @@ proc createMembershipList*(n: int): (seq[(string, string)], string) {.raises: [
   let root = rln.getMerkleRoot().value.toHex
   return (output, root)
 
-proc rlnRelayStaticSetUp*(rlnRelayMemIndex: MembershipIndex): (Option[seq[
+proc rlnRelayStaticSetUp*(rlnRelayMembershipIndex: MembershipIndex): (Option[seq[
     IDCommitment]], Option[MembershipKeyPair], Option[
     MembershipIndex]) {.raises: [Defect, ValueError].} =
   let
@@ -661,10 +661,10 @@ proc rlnRelayStaticSetUp*(rlnRelayMemIndex: MembershipIndex): (Option[seq[
     groupKeys = StaticGroupKeys
     groupSize = StaticGroupSize
 
-  debug "rln-relay membership index", rlnRelayMemIndex
+  debug "rln-relay membership index", rlnRelayMembershipIndex
 
   # validate the user-supplied membership index
-  if rlnRelayMemIndex < MembershipIndex(0) or rlnRelayMemIndex >=
+  if rlnRelayMembershipIndex < MembershipIndex(0) or rlnRelayMembershipIndex >=
       MembershipIndex(groupSize):
     error "wrong membership index"
     return(none(seq[IDCommitment]), none(MembershipKeyPair), none(MembershipIndex))
@@ -677,8 +677,8 @@ proc rlnRelayStaticSetUp*(rlnRelayMemIndex: MembershipIndex): (Option[seq[
     groupIDCommitments = groupKeyPairs.mapIt(it.idCommitment)
     groupOpt = some(groupIDCommitments)
     # user selected membership key pair
-    memKeyPairOpt = some(groupKeyPairs[rlnRelayMemIndex])
-    memIndexOpt = some(rlnRelayMemIndex)
+    memKeyPairOpt = some(groupKeyPairs[rlnRelayMembershipIndex])
+    memIndexOpt = some(rlnRelayMembershipIndex)
 
   return (groupOpt, memKeyPairOpt, memIndexOpt)
 
@@ -1130,7 +1130,7 @@ proc mount(node: WakuNode,
   if not conf.rlnRelayDynamic:
     info " setting up waku-rln-relay in off-chain mode... "
     # set up rln relay inputs
-    let (groupOpt, memKeyPairOpt, memIndexOpt) = rlnRelayStaticSetUp(MembershipIndex(conf.rlnRelayMemIndex))
+    let (groupOpt, memKeyPairOpt, memIndexOpt) = rlnRelayStaticSetUp(MembershipIndex(conf.rlnRelayMembershipIndex))
     if memIndexOpt.isNone:
       error "failed to mount WakuRLNRelay"
     else:

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1164,7 +1164,7 @@ proc mount(node: WakuNode,
     let 
       ethAccountAddr = web3.fromHex(web3.Address, conf.rlnRelayEthAccount)
       ethClientAddr = conf.rlnRelayEthClientAddress
-      ethMemContractAddress = web3.fromHex(web3.Address, conf.rlnRelayEthMemContractAddress)
+      ethMemContractAddress = web3.fromHex(web3.Address, conf.rlnRelayEthContractAddress)
     var ethAccountPrivKeyOpt = none(keys.PrivateKey)
     if conf.rlnRelayEthAccountPrivKey != "":
       ethAccountPrivKeyOpt = some(keys.PrivateKey(SkSecretKey.fromHex(conf.rlnRelayEthAccountPrivKey).value))

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1166,8 +1166,8 @@ proc mount(node: WakuNode,
       ethClientAddr = conf.rlnRelayEthClientAddress
       ethMemContractAddress = web3.fromHex(web3.Address, conf.rlnRelayEthContractAddress)
     var ethAccountPrivKeyOpt = none(keys.PrivateKey)
-    if conf.rlnRelayEthAccountPrivKey != "":
-      ethAccountPrivKeyOpt = some(keys.PrivateKey(SkSecretKey.fromHex(conf.rlnRelayEthAccountPrivKey).value))
+    if conf.rlnRelayEthAccountPrivateKey != "":
+      ethAccountPrivKeyOpt = some(keys.PrivateKey(SkSecretKey.fromHex(conf.rlnRelayEthAccountPrivateKey).value))
       
     # if the rlnRelayCredPath config option is non-empty, then rln-relay credentials should be persisted
     # if the path does not contain any credential file, then a new set is generated and pesisted in the same path


### PR DESCRIPTION
Should resolve https://github.com/status-im/nwaku/issues/1196

This PR namespaces few flags that are exclusively used with rln-relay. This will 
unblock https://github.com/status-im/infra-role-nim-waku/pull/5 and 
https://github.com/status-im/infra-nim-waku/pull/61
