### PR TITLE
fix(store): update sqlite db table primary key and decouple queries module from pagination types

### DIFF
--- a/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
+++ b/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
@@ -98,6 +98,7 @@ method getMessagesByHistoryQuery*(
   maxPageSize = DefaultPageSize,
   ascendingOrder = true
 ): MessageStoreResult[MessageStorePage] =
+  let cursor = cursor.map(proc(c: PagingIndex): DbCursor = (c.receiverTime, @(c.digest.data), c.pubsubTopic))
 
   let rows = ?s.db.selectMessagesByHistoryQueryWithLimit(
     contentTopic, 

--- a/waku/v2/node/storage/migration/migration_types.nim
+++ b/waku/v2/node/storage/migration/migration_types.nim
@@ -7,7 +7,7 @@ const MESSAGE_STORE_MIGRATION_PATH* = sourceDir / "migrations_scripts/message"
 const PEER_STORE_MIGRATION_PATH* = sourceDir / "migrations_scripts/peer"
 const ALL_STORE_MIGRATION_PATH* = sourceDir / "migrations_scripts"
 
-const USER_VERSION* = 6 # increase this when there is an update in the database schema
+const USER_VERSION* = 7 # increase this when there is an update in the database schema
 
 type MigrationScriptsResult*[T] = Result[T, string]
 type

--- a/waku/v2/node/storage/migration/migrations_scripts/message/00007_updatePrimaryKey.up.sql
+++ b/waku/v2/node/storage/migration/migrations_scripts/message/00007_updatePrimaryKey.up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE message RENAME TO message_backup;
+
+CREATE TABLE IF NOT EXISTS message(
+  pubsubTopic BLOB NOT NULL,
+  contentTopic BLOB NOT NULL,
+  payload BLOB,
+  version INTEGER NOT NULL,
+  timestamp INTEGER NOT NULL,
+  id BLOB,
+  storedAt INTEGER NOT NULL,
+  CONSTRAINT messageIndex PRIMARY KEY (storedAt, id, pubsubTopic)
+) WITHOUT ROWID;
+
+INSERT INTO message(pubsubTopic, contentTopic, payload, version, timestamp, id, storedAt)
+  SELECT pubsubTopic, contentTopic, payload, version, senderTimestamp, id, storedAt
+  FROM message_backup;
+
+DROP TABLE message_backup;

--- a/waku/v2/node/storage/migration/migrations_scripts/message/00007_updatePrimaryKey.up.sql
+++ b/waku/v2/node/storage/migration/migrations_scripts/message/00007_updatePrimaryKey.up.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS message(
   CONSTRAINT messageIndex PRIMARY KEY (storedAt, id, pubsubTopic)
 ) WITHOUT ROWID;
 
-INSERT INTO message(pubsubTopic, contentTopic, payload, version, timestamp, id, storedAt)
+INSERT OR IGNORE INTO message(pubsubTopic, contentTopic, payload, version, timestamp, id, storedAt)
   SELECT pubsubTopic, contentTopic, payload, version, senderTimestamp, id, storedAt
   FROM message_backup;
 


### PR DESCRIPTION
This PR is part of the "fix waku store pagination" series:

- [x] Simplify store queue query implementation
- [x] Update SQLite DB table primary key
- [x] Decouple SQLite queries module from pagination types
- [ ] Move page info logic to waku store protocol

In this PR:

- Update SQLite DB table primary key
- Rename `senderTimestamp` column to `timestamp`
- Extend history query order by clause for results consistency
- Decouple `sqlite_store/queries` module from `pagination` module types
- Update test cases accordingly
