### PR TITLE
fix(store): Move page info logic to waku store protocol

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -266,7 +266,7 @@ procSuite "Waku v2 JSON-RPC API":
     let response = await client.get_waku_v2_store_v1_messages(some(defaultTopic), some(@[HistoryContentFilter(contentTopic: defaultContentTopic)]), some(Timestamp(0)), some(Timestamp(9)), some(StorePagingOptions()))
     check:
       response.messages.len() == 8
-      response.pagingOptions.isSome()
+      response.pagingOptions.isNone()
       
     await server.stop()
     await server.closeWait()

--- a/tests/v2/test_message_store_queue_pagination.nim
+++ b/tests/v2/test_message_store_queue_pagination.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options, sequtils, times],
+  std/[options, sequtils, times, algorithm],
   testutils/unittests, 
   nimcrypto/sha2,
   libp2p/protobuf/minprotobuf
@@ -53,69 +53,49 @@ suite "Queue store - pagination":
     var pagingInfo = PagingInfo(pageSize: 2, cursor: indexList[3].toPagingIndex(), direction: PagingDirection.FORWARD)
 
     # test for a normal pagination
-    var (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    var data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 2
       data == msgList[4..5]
-      newPagingInfo.cursor == indexList[5].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == pagingInfo.pageSize
    
    # test for an initial pagination request with an empty cursor
     pagingInfo = PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 2
       data == msgList[0..1]
-      newPagingInfo.cursor == indexList[1].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 2
     
     # test for an initial pagination request with an empty cursor to fetch the entire history
     pagingInfo = PagingInfo(pageSize: 13, direction: PagingDirection.FORWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 10
       data == msgList[0..9]
-      newPagingInfo.cursor == indexList[9].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 10
 
     # test for an empty msgList
     pagingInfo = PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD)
-    (data, newPagingInfo) = getPage(getTestStoreQueue(0), pagingInfo).tryGet()
+    data = getPage(getTestStoreQueue(0), pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 0
-      newPagingInfo.pageSize == 0
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.cursor == pagingInfo.cursor
 
     # test for a page size larger than the remaining messages
     pagingInfo = PagingInfo(pageSize: 10, cursor: indexList[3].toPagingIndex(), direction: PagingDirection.FORWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 6
       data == msgList[4..9]
-      newPagingInfo.cursor == indexList[9].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 6
 
     # test for a page size larger than the maximum allowed page size
     pagingInfo = PagingInfo(pageSize: MaxPageSize+1, cursor: indexList[3].toPagingIndex(), direction: PagingDirection.FORWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       uint64(data.len) <= MaxPageSize
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize <= MaxPageSize
   
     # test for a cursor pointing to the end of the message list
     pagingInfo = PagingInfo(pageSize: 10, cursor: indexList[9].toPagingIndex(), direction: PagingDirection.FORWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 0
-      newPagingInfo.cursor == indexList[9].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 0
     
     # test for an invalid cursor 
     let index = PagingIndex.compute(WakuMessage(payload: @[byte 10]), ts(), DefaultPubsubTopic)
@@ -127,22 +107,16 @@ suite "Queue store - pagination":
     # test initial paging query over a message list with one message 
     var singleItemMsgList = getTestStoreQueue(1)
     pagingInfo = PagingInfo(pageSize: 10, direction: PagingDirection.FORWARD)
-    (data, newPagingInfo) = getPage(singleItemMsgList, pagingInfo).tryGet()
+    data = getPage(singleItemMsgList, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 1
-      newPagingInfo.cursor == indexList[0].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 1
 
     # test pagination over a message list with one message
     singleItemMsgList = getTestStoreQueue(1)
     pagingInfo = PagingInfo(pageSize: 10, cursor: indexList[0].toPagingIndex(), direction: PagingDirection.FORWARD)
-    (data, newPagingInfo) = getPage(singleItemMsgList, pagingInfo).tryGet()
+    data = getPage(singleItemMsgList, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 0
-      newPagingInfo.cursor == indexList[0].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 0
 
   test "Backward pagination test":
     let
@@ -153,68 +127,47 @@ suite "Queue store - pagination":
     var pagingInfo = PagingInfo(pageSize: 2, cursor: indexList[3].toPagingIndex(), direction: PagingDirection.BACKWARD)
 
     # test for a normal pagination
-    var (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    var data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
-      data == msgList[1..2]
-      newPagingInfo.cursor == indexList[1].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == pagingInfo.pageSize
+      data == msgList[1..2].reversed
 
     # test for an empty msgList
     pagingInfo = PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD)
-    (data, newPagingInfo) = getPage(getTestStoreQueue(0), pagingInfo).tryGet()
+    data = getPage(getTestStoreQueue(0), pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 0
-      newPagingInfo.pageSize == 0
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.cursor == pagingInfo.cursor
 
     # test for an initial pagination request with an empty cursor
     pagingInfo = PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 2
-      data == msgList[8..9]
-      newPagingInfo.cursor == indexList[8].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 2
+      data == msgList[8..9].reversed
     
     # test for an initial pagination request with an empty cursor to fetch the entire history
     pagingInfo = PagingInfo(pageSize: 13, direction: PagingDirection.BACKWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 10
-      data == msgList[0..9]
-      newPagingInfo.cursor == indexList[0].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 10
+      data == msgList[0..9].reversed
 
     # test for a page size larger than the remaining messages
     pagingInfo = PagingInfo(pageSize: 5, cursor: indexList[3].toPagingIndex(), direction: PagingDirection.BACKWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
-      data == msgList[0..2]
-      newPagingInfo.cursor == indexList[0].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 3
+      data == msgList[0..2].reversed
     
     # test for a page size larger than the Maximum allowed page size
     pagingInfo = PagingInfo(pageSize: MaxPageSize+1, cursor: indexList[3].toPagingIndex(), direction: PagingDirection.BACKWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       uint64(data.len) <= MaxPageSize
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize <= MaxPageSize
 
     # test for a cursor pointing to the begining of the message list
     pagingInfo = PagingInfo(pageSize: 5, cursor: indexList[0].toPagingIndex(), direction: PagingDirection.BACKWARD)
-    (data, newPagingInfo) = getPage(store, pagingInfo).tryGet()
-
+    data = getPage(store, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 0
-      newPagingInfo.cursor == indexList[0].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 0
 
     # test for an invalid cursor 
     let index = PagingIndex.compute(WakuMessage(payload: @[byte 10]), ts(), DefaultPubsubTopic)
@@ -226,19 +179,13 @@ suite "Queue store - pagination":
     # test initial paging query over a message list with one message
     var singleItemMsgList = getTestStoreQueue(1)
     pagingInfo = PagingInfo(pageSize: 10, direction: PagingDirection.BACKWARD)
-    (data, newPagingInfo) = getPage(singleItemMsgList, pagingInfo).tryGet()
+    data = getPage(singleItemMsgList, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 1
-      newPagingInfo.cursor == indexList[0].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 1
     
     # test paging query over a message list with one message
     singleItemMsgList = getTestStoreQueue(1)
     pagingInfo = PagingInfo(pageSize: 10, cursor: indexList[0].toPagingIndex(), direction: PagingDirection.BACKWARD)
-    (data, newPagingInfo) = getPage(singleItemMsgList, pagingInfo).tryGet()
+    data = getPage(singleItemMsgList, pagingInfo).tryGet().mapIt(it[1])
     check:
       data.len == 0
-      newPagingInfo.cursor == indexList[0].toPagingIndex()
-      newPagingInfo.direction == pagingInfo.direction
-      newPagingInfo.pageSize == 0

--- a/tests/v2/test_message_store_sqlite.nim
+++ b/tests/v2/test_message_store_sqlite.nim
@@ -4,8 +4,7 @@ import
   std/[unittest, options, tables, sets, times, strutils, sequtils, os],
   stew/byteutils,
   chronos,
-  chronicles,
-  sqlite3_abi
+  chronicles
 import
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/storage/message/message_retention_policy,
@@ -95,7 +94,7 @@ suite "SQLite message store - insert messages":
     check:
       storedMsg.len == 1
       storedMsg.all do (item: auto) -> bool:
-        let (_, msg, pubsubTopic) = item
+        let (pubsubTopic, msg, digest, storeTimestamp) = item
         msg.contentTopic == contentTopic and
         pubsubTopic == DefaultPubsubTopic
     
@@ -133,7 +132,7 @@ suite "SQLite message store - insert messages":
     check:
       storedMsg.len == storeCapacity
       storedMsg.all do (item: auto) -> bool:
-        let (_, msg, pubsubTopic) = item
+        let (pubsubTopic, msg, digest, storeTimestamp) = item
         msg.contentTopic == contentTopic and
         pubsubTopic == DefaultPubsubTopic
 
@@ -186,7 +185,7 @@ suite "Message Store":
     # flags for receiver timestamp
     var rt1Flag, rt2Flag, rt3Flag: bool = false
 
-    for (receiverTimestamp, msg, pubsubTopic) in result:
+    for (pubsubTopic, msg, digest, receiverTimestamp) in result:
       check:
         pubsubTopic == DefaultPubsubTopic
 

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -444,9 +444,7 @@ suite "Waku Store - history query":
       ## No pagination specified. Response will be auto-paginated with
       ## up to MaxPageSize messages per page.
       response.messages.len() == 8
-      response.pagingInfo.pageSize == 8
-      response.pagingInfo.direction == PagingDirection.BACKWARD
-      response.pagingInfo.cursor != PagingIndex()
+      response.pagingInfo == PagingInfo()
 
     ## Cleanup
     await allFutures(clientSwitch.stop(), serverSwitch.stop())

--- a/waku/v2/node/storage/message/dual_message_store.nim
+++ b/waku/v2/node/storage/message/dual_message_store.nim
@@ -33,9 +33,8 @@ proc init*(T: type DualMessageStore, db: SqliteDatabase, capacity: int): Message
   if res.isErr():
     warn "failed to load messages from the persistent store", err = res.error
   else: 
-    for (receiverTime, msg, pubsubTopic) in res.value:
-      let digest = computeDigest(msg)
-      discard inmemory.put(pubsubTopic, msg, digest, receiverTime)
+    for (pubsubTopic, msg, _, storeTimestamp) in res.value:
+      discard inmemory.put(pubsubTopic, msg, computeDigest(msg), storeTimestamp)
 
     info "successfully loaded messages from the persistent store"
 
@@ -65,7 +64,7 @@ method getMessagesByHistoryQuery*(
   endTime = none(Timestamp),
   maxPageSize = MaxPageSize,
   ascendingOrder = true
-): MessageStoreResult[MessageStorePage] =
+): MessageStoreResult[seq[MessageStoreRow]] =
   s.inmemory.getMessagesByHistoryQuery(contentTopic, pubsubTopic, cursor, startTime, endTime, maxPageSize, ascendingOrder)
 
 

--- a/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
+++ b/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
@@ -74,7 +74,7 @@ method put*(s: SqliteStore, pubsubTopic: string, message: WakuMessage, digest: M
     message.timestamp              # senderTimestamp
   ))
   if res.isErr():
-    return err("message insert failed: " & res.error())
+    return err("message insert failed: " & res.error)
 
   ok()
 
@@ -97,10 +97,10 @@ method getMessagesByHistoryQuery*(
   endTime = none(Timestamp),
   maxPageSize = DefaultPageSize,
   ascendingOrder = true
-): MessageStoreResult[MessageStorePage] =
+): MessageStoreResult[seq[MessageStoreRow]] =
   let cursor = cursor.map(proc(c: PagingIndex): DbCursor = (c.receiverTime, @(c.digest.data), c.pubsubTopic))
 
-  let rows = ?s.db.selectMessagesByHistoryQueryWithLimit(
+  return s.db.selectMessagesByHistoryQueryWithLimit(
     contentTopic, 
     pubsubTopic, 
     cursor,
@@ -109,29 +109,6 @@ method getMessagesByHistoryQuery*(
     limit=maxPageSize,
     ascending=ascendingOrder
   )
-
-  if rows.len <= 0:
-    return ok((@[], none(PagingInfo)))
-
-  var messages = rows.mapIt(it[0])
-
-  # TODO: Return the message hash from the DB, to avoid recomputing the hash of the last message
-  # Compute last message index
-  let (message, storedAt, pubsubTopic) = rows[^1]
-  let lastIndex = PagingIndex.compute(message, storedAt, pubsubTopic)
-
-  let pagingInfo = PagingInfo(
-    pageSize: uint64(messages.len),
-    cursor: lastIndex,
-    direction: if ascendingOrder: PagingDirection.FORWARD
-               else: PagingDirection.BACKWARD
-  )
-
-  # The retrieved messages list should always be in chronological order
-  if not ascendingOrder:
-    messages.reverse()
-
-  ok((messages, some(pagingInfo)))
 
 
 method getMessagesCount*(s: SqliteStore): MessageStoreResult[int64] =

--- a/waku/v2/protocol/waku_store/message_store.nim
+++ b/waku/v2/protocol/waku_store/message_store.nim
@@ -15,9 +15,7 @@ import
 type
   MessageStoreResult*[T] = Result[T, string]
   
-  MessageStorePage* = (seq[WakuMessage], Option[PagingInfo])
-
-  MessageStoreRow* = (Timestamp, WakuMessage, string)
+  MessageStoreRow* = (string, WakuMessage, seq[byte], Timestamp)
 
   MessageStore* = ref object of RootObj
 
@@ -44,7 +42,7 @@ method getMessagesByHistoryQuery*(
   endTime = none(Timestamp),
   maxPageSize = DefaultPageSize,
   ascendingOrder = true
-): MessageStoreResult[MessageStorePage] {.base.} = discard
+): MessageStoreResult[seq[MessageStoreRow]] {.base.} = discard
 
 
 # Store manipulation


### PR DESCRIPTION
This PR is part of the "fix waku store pagination" series:

- [x] Simplify store queue query implementation
- [x] Update SQLite DB table primary key
- [x] Decouple SQLite queries module from pagination types
- [x] Move page info logic to waku store protocol

In this PR:

- Simplify the message store interface and update message store implementations accordingly
- Move paging info calculation to the protocol module
- Fix pagination logic: `Always search for _max page size_ + 1. If the extra row does not exist, do not return pagination info.` 
- Update test cases accordingly
