### PR TITLE
[WIP] ci: use Nix shell to provide build dependencies

### DIFF
--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.18'
+library 'status-jenkins-lib@v1.6.0'
 
 pipeline {
   agent { label "${getAgentLabel()} && x86_64" }
@@ -53,19 +53,23 @@ pipeline {
       v1changed = versionWasChanged('v1')
       v2changed = versionWasChanged('v2')
       /* TODO: Re-add caching of Nim compiler. */
-      sh "make V=${params.VERBOSITY} update"
-      sh "make V=${params.VERBOSITY} deps"
+      nix.shell("make V=${params.VERBOSITY} update", pure: false)
+      nix.shell("make V=${params.VERBOSITY} deps", pure: false)
     } } }
 
     stage('Binaries') {
       parallel {
         stage('V1') { 
           when { expression { v1changed } }
-          steps { sh "make V=${params.VERBOSITY} v1" }
+          steps { script {
+            nix.shell("make V=${params.VERBOSITY} v1")
+          } }
         }
         stage('V2') {
           when { expression { v2changed } }
-          steps { sh "make V=${params.VERBOSITY} v2" }
+          steps { script {
+            nix.shell("make V=${params.VERBOSITY} v2")
+          } }
         }
       }
     }
@@ -74,11 +78,15 @@ pipeline {
       parallel {
         stage('V1') {
           when { expression { v1changed } }
-          steps { sh "make V=${params.VERBOSITY} test1" }
+          steps { script {
+            nix.shell("make V=${params.VERBOSITY} test1")
+          } }
         }
         stage('V2') {
           when { expression { v2changed } }
-          steps { sh "make V=${params.VERBOSITY} test2" }
+          steps { script {
+            nix.shell("make V=${params.VERBOSITY} test2")
+          } }
         }
       }
     }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/dbf1d73cd1a17276196afeee169b4cf7834b7a96.tar.gz";
+  sha256 = "sha256:1k5nvn2yzw370cqsfh62lncsgydq2qkbjrx34cprzf0k6b93v7ch";
+}) {} }:
+
+pkgs.mkShell {
+  name = "nim-waku-build-shell";
+
+  # Versions dependent on nixpkgs commit. Update manually.
+  buildInputs = with pkgs; [
+    git   # 2.37.3
+    which # 2.21
+    gcc   # 11.3.0
+    rustc # 1.63.0
+  ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
+}


### PR DESCRIPTION
Because we need Rust version newer than `1.62.0` and Ubuntu 22.04 only comes with `1.61.0`:
https://packages.ubuntu.com/jammy/rustc

And locking dependencies using Nix would make it easier for developers to track them and update them:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/rust/1_63.nix