### PR TITLE
fix: store config without db-path causes SIGSEGV crash

### DIFF
--- a/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
+++ b/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
@@ -19,6 +19,10 @@ logScope:
 
 
 proc init(db: SqliteDatabase): MessageStoreResult[void] =
+  ## Misconfiguration can lead to nil DB
+  if db.isNil():
+    return err("db not initialized")
+
   # Create table, if doesn't exist
   let resCreate = createTable(db)
   if resCreate.isErr():

--- a/waku/v2/node/storage/peer/waku_peer_storage.nim
+++ b/waku/v2/node/storage/peer/waku_peer_storage.nim
@@ -61,6 +61,9 @@ proc encode*(storedInfo: StoredInfo): PeerStorageResult[ProtoBuffer] =
 ##########################
 
 proc new*(T: type WakuPeerStorage, db: SqliteDatabase): PeerStorageResult[T] =
+  ## Misconfiguration can lead to nil DB
+  if db.isNil():
+    return err("db not initialized")
   
   ## Create the "Peer" table
   ## It contains:


### PR DESCRIPTION
Fixes https://github.com/status-im/nwaku/issues/1188

Currently enabling store without setting an explicit `--db-path` leads to a crash with message [`SIGSEGV: Illegal storage access.`](https://github.com/status-im/nwaku/issues/1188). This is because both the sqlite-only store and dual message store requires a functioning, initialised database. It should be possible to configure nwaku with an in-memory store only.

This PR:
- enables configuring nwaku without an external db-path (in-memory only)
- ensures DB misconfiguration leads to an init error and not a failure/crash (both for message and peer stores)

Note that this simply fixes operation using the existing config items. Reworking `store` config is being tracked in https://github.com/status-im/nwaku/issues/1217