### PR TITLE
ci: install 1.64 rust in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
 # BUILD IMAGE --------------------------------------------------------
 
-FROM alpine:3.15 AS nim-build
+FROM alpine:3.16 AS nim-build
 
 ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2
-ARG RLN=true
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git rust cargo build-base pcre-dev linux-headers
+RUN apk add --no-cache bash git cargo build-base pcre-dev linux-headers
+
+# Install newer rust than 1.62 as required by ethers-core.
+ENV PKG=rust-1.64.0-x86_64-unknown-linux-musl
+RUN wget -q https://static.rust-lang.org/dist/$PKG.tar.gz \
+ && tar xf $PKG.tar.gz \
+ && cd $PKG \
+ && ./install.sh --components=rustc,cargo,rust-std-x86_64-unknown-linux-musl \
+ && cd - \
+ && rm -r $PKG $PKG.tar.gz
 
 WORKDIR /app
 COPY . .
@@ -16,13 +24,14 @@ COPY . .
 RUN git submodule update --init --recursive
 
 # Slowest build step for the sake of caching layers
-RUN make -j$(nproc) deps RLN="$RLN"
+RUN make -j$(nproc) deps
 
 # Build the final node binary
-RUN make -j$(nproc) $MAKE_TARGET NIMFLAGS="$NIMFLAGS" RLN="$RLN"
+RUN make -j$(nproc) $MAKE_TARGET NIMFLAGS="$NIMFLAGS"
+
 # ACTUAL IMAGE -------------------------------------------------------
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 ARG MAKE_TARGET=wakunode2
 
@@ -42,10 +51,6 @@ RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
 # Copy to separate location to accomodate different MAKE_TARGET values
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
-
-# If rln enabled: fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
-COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
-COPY --from=nim-build /app/waku/v2/protocol/waku_rln_relay/parameters.key waku/v2/protocol/waku_rln_relay/parameters.key
 
 # Copy migration scripts for DB upgrades
 COPY --from=nim-build /app/waku/v2/node/storage/migration/migrations_scripts/ /app/waku/v2/node/storage/migration/migrations_scripts/


### PR DESCRIPTION
Necessary to fix errors like:
```
error: package `ethers-core v0.17.0 (https://github.com/gakonst/ethers-rs#454449b0)` cannot be built
because it requires rustc 1.62 or newer, while the currently active rustc version is 1.60.0
```
Also upgraded Alpine from `3.15` to `3.16`.

Related:

* https://github.com/status-im/nwaku/pull/1216