### PR TITLE
chore: publish nwaku version to metric

### DIFF
--- a/waku/v2/node/jsonrpc/debug_api.nim
+++ b/waku/v2/node/jsonrpc/debug_api.nim
@@ -8,9 +8,6 @@ import
 logScope:
   topics = "debug api"
 
-const 
-  git_version {.strdefine.} = "n/a"
-
 proc installDebugApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   ## Debug API version 1 definitions

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -39,12 +39,16 @@ export
 when defined(rln) or defined(rlnzerokit):
   import ../protocol/waku_rln_relay/waku_rln_relay_utils
 
+declarePublicGauge waku_version, "Waku version info (in git describe format)", ["version"]
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]
 declarePublicGauge waku_node_filters, "number of content filter subscriptions"
 declarePublicGauge waku_node_errors, "number of wakunode errors", ["type"]
 
 logScope:
   topics = "wakunode"
+
+# Git version in git describe format (defined compile time)
+const git_version* {.strdefine.} = "n/a"
 
 # Default clientId
 const clientId* = "Nimbus Waku v2 node"
@@ -759,6 +763,8 @@ proc start*(node: WakuNode) {.async.} =
   ##
   ## Status: Implemented.
   
+  waku_version.set(1, labelValues=[git_version])
+  
   ## NB: careful when moving this. We need to start the switch with the bind address
   ## BEFORE updating with announced addresses for the sake of identify.
   await node.switch.start()
@@ -1185,7 +1191,6 @@ when isMainModule:
 
   # if called with --version, print the version and quit
   if conf.version:
-    const git_version {.strdefine.} = "n/a"
     echo "version / git commit hash: ", git_version
     quit(QuitSuccess)
   


### PR DESCRIPTION
Closes https://github.com/status-im/nwaku/issues/1125.

Publishes the nwaku `git_version` to a metric with the label value matching the version. For now the label format matches the `git describe` format, though we should consider more explicit, parsed versioning information similar to nimbus in future.