### PR TITLE
ci: use rust:1.64.0-slim-bullseye image without musl

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,11 @@
-/README.md
-/Dockerfile
-/.*ignore
-/LICENSE*
-/tests
-/metrics
+README.md
+Dockerfile
+.*ignore
+LICENSE*
+build
+ci
+docs
+examples
+metrics
+tests
 **/vendor/*

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -16,6 +16,11 @@ pipeline {
    * See 'environment' section. */
   parameters {
     string(
+      name: 'RELEASE',
+      description: 'Enable pushing built docker image.',
+      defaultValue: params.RELEASE ?: false,
+    )
+    string(
       name: 'MAKE_TARGET',
       description: 'Makefile target to build. Optional Parameter.',
       defaultValue: params.MAKE_TARGET ?: 'wakunode2',
@@ -55,6 +60,7 @@ pipeline {
     }
 
     stage('Push') {
+      when { params.RELEASE }
       steps { script {
         withDockerRegistry([credentialsId: "dockerhub-statusteam-auto", url: ""]) {
           image.push()
@@ -65,31 +71,33 @@ pipeline {
   } // stages
   post {
     success { script {
-      withCredentials([
-        string(
-          credentialsId: 'discord-waku-deployments-webhook',
-          variable: 'DISCORD_WEBHOOK'
-        ),
-      ]) {
-        def repo = [
-          url: 'https://github.com/status-im/nwaku',
-          branch: GIT_BRANCH.minus("origin/"),
-          commit: GIT_COMMIT.take(8),
-          prev: (env.GIT_PREVIOUS_SUCCESSFUL_COMMIT ?: env.GIT_PREVIOUS_COMMIT ?: 'master').take(8),
-        ]
-        discordSend(
-          title: "${env.JOB_NAME}#${env.BUILD_NUMBER}",
-          description: """
-            Nim-Waku deployment successful!
-            Image: [`${IMAGE_NAME}:${IMAGE_TAG}`](https://hub.docker.com/r/${IMAGE_NAME}/tags?name=${IMAGE_TAG})
-            Branch: [`${repo.branch}`](${repo.url}/commits/${repo.branch})
-            Commit: [`${repo.commit}`](${repo.url}/commit/${repo.commit})
-            Diff: [`${repo.prev}...${repo.commit}`](${repo.url}/compare/${repo.prev}...${repo.commit})
-          """,
-          link: env.BUILD_URL,
-          result: currentBuild.currentResult,
-          webhookURL: env.DISCORD_WEBHOOK
-        )
+      if (params.RELEASE) {
+        withCredentials([
+          string(
+            credentialsId: 'discord-waku-deployments-webhook',
+            variable: 'DISCORD_WEBHOOK'
+          ),
+        ]) {
+          def repo = [
+            url: 'https://github.com/status-im/nwaku',
+            branch: GIT_BRANCH.minus("origin/"),
+            commit: GIT_COMMIT.take(8),
+            prev: (env.GIT_PREVIOUS_SUCCESSFUL_COMMIT ?: env.GIT_PREVIOUS_COMMIT ?: 'master').take(8),
+          ]
+          discordSend(
+            title: "${env.JOB_NAME}#${env.BUILD_NUMBER}",
+            description: """
+              Nim-Waku deployment successful!
+              Image: [`${IMAGE_NAME}:${IMAGE_TAG}`](https://hub.docker.com/r/${IMAGE_NAME}/tags?name=${IMAGE_TAG})
+              Branch: [`${repo.branch}`](${repo.url}/commits/${repo.branch})
+              Commit: [`${repo.commit}`](${repo.url}/commit/${repo.commit})
+              Diff: [`${repo.prev}...${repo.commit}`](${repo.url}/compare/${repo.prev}...${repo.commit})
+            """,
+            link: env.BUILD_URL,
+            result: currentBuild.currentResult,
+            webhookURL: env.DISCORD_WEBHOOK
+          )
+        }
       }
     } }
     always { sh 'docker image prune -f' }


### PR DESCRIPTION
This is necessary for generating the `zerokit` `librln` dynamic library. Otherwise we get:
```
warning: dropping unsupported crate type `cdylib` for target `x86_64-unknown-linux-musl`
```