### PR TITLE
chore(rln-relay): Use kilic rln in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,6 @@ ARG RLN=true
 # Get build tools and required header files
 RUN apk add --no-cache bash git cargo build-base pcre-dev linux-headers
 
-# Install newer rust than 1.62 as required by ethers-core.
-ENV PKG=rust-1.64.0-x86_64-unknown-linux-musl
-RUN wget -q https://static.rust-lang.org/dist/$PKG.tar.gz \
- && tar xf $PKG.tar.gz \
- && cd $PKG \
- && ./install.sh --components=rustc,cargo,rust-std-x86_64-unknown-linux-musl \
- && cd - \
- && rm -r $PKG $PKG.tar.gz
-
 WORKDIR /app
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ COPY . .
 RUN git submodule update --init --recursive
 
 # Slowest build step for the sake of caching layers
-RUN make -j$(nproc) deps RLN="$RLN"
+RUN make -j$(nproc) deps RLNKILIC="$RLN"
 
 # Build the final node binary
-RUN make -j$(nproc) $MAKE_TARGET NIMFLAGS="$NIMFLAGS" RLN="$RLN"
+RUN make -j$(nproc) $MAKE_TARGET NIMFLAGS="$NIMFLAGS" RLNKILIC="$RLN"
 
 # ACTUAL IMAGE -------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 
 # If rln enabled: fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
-COPY --from=nim-build /app/vendor/zerokit/target/release/librln.so vendor/zerokit/target/release/librln.so
-COPY --from=nim-build /app/vendor/zerokit/rln/resources/ vendor/zerokit/rln/resources/
+COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
+COPY --from=nim-build /app/waku/v2/protocol/waku_rln_relay/parameters.key waku/v2/protocol/waku_rln_relay/parameters.key
 
 # Copy migration scripts for DB upgrades
 COPY --from=nim-build /app/waku/v2/node/storage/migration/migrations_scripts/ /app/waku/v2/node/storage/migration/migrations_scripts/


### PR DESCRIPTION
Preserve existing changes, but use kilic's rln instead of zerokit