### PR TITLE
fix(store): fix store validity timestamp variance constant

### DIFF
--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -44,7 +44,7 @@ const
 
   DefaultTopic* = "/waku/2/default-waku/proto"
 
-  MaxMessageTimestampVariance* = Timestamp(20.seconds.nanoseconds) # 20 seconds maximum allowable sender timestamp "drift"
+  MaxMessageTimestampVariance* = getNanoSecondTime(20) # 20 seconds maximum allowable sender timestamp "drift"
 
 
 # Error types (metric label values)


### PR DESCRIPTION
Fix the constant definition. Seems that using chronos' `seconds` and `nanoseconds` procs set the constant to 0. The changes revert to the original way of defining the constant. 