### PR TITLE
test(rln-relay): setup heartbeat ws subscription and log when connection drops

### DIFF
--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -824,8 +824,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
 
   ## TODO: FIXME after resolving this issue https://github.com/status-im/nwaku/issues/1247
   if not rlnPeer.validateRoot(msg.proof.merkleRoot):
-    debug "invalid message: provided root does not belong to acceptable window of roots", provided=msg.proof.merkleRoot, validRoots=rlnPeer.validMerkleRoots
-    waku_rln_invalid_messages_total.inc(labelValues=["invalid_root"])
+    debug "invalid message: provided root does not belong to acceptable window of roots", provided=msg.proof.merkleRoot, validRoots=rlnPeer.validMerkleRoots.mapIt("0x" & (it.toHex))    waku_rln_invalid_messages_total.inc(labelValues=["invalid_root"])
   #   return MessageValidationResult.Invalid
 
   # verify the proof
@@ -1121,7 +1120,7 @@ proc mountRlnRelayDynamic*(node: WakuNode,
     let pk = pubkey.toIDCommitment()
     let isSuccessful = rlnPeer.insertMember(pk)
     debug "received pk", pk=pk.toHex, index =index
-    debug "acceptable window", validRoots=rlnPeer.validMerkleRoots
+    debug "acceptable window", validRoots=rlnPeer.validMerkleRoots.mapIt("0x" & (it.toHex))
     doAssert(isSuccessful.isOk())
 
   asyncSpawn rlnPeer.handleGroupUpdates(handler)

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -925,7 +925,7 @@ proc subscribeToGroupEvents(ethClientUri: string, ethAccountAddress: Address, co
   ## it collects all the events starting from the given `blockNumber`
   ## for every received event, it calls the `handler`
   let web3 = await newWeb3(ethClientUri)
-  var latestBlock = "0x0"
+  var latestBlock: Quantity
   let newHeadCallback = proc (blockheader: BlockHeader) {.gcsafe.} =
     latestBlock = blockheader.number
     debug "block received", blockNumber = latestBlock

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -824,7 +824,8 @@ proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
 
   ## TODO: FIXME after resolving this issue https://github.com/status-im/nwaku/issues/1247
   if not rlnPeer.validateRoot(msg.proof.merkleRoot):
-    debug "invalid message: provided root does not belong to acceptable window of roots", provided=msg.proof.merkleRoot, validRoots=rlnPeer.validMerkleRoots.mapIt("0x" & (it.toHex))    waku_rln_invalid_messages_total.inc(labelValues=["invalid_root"])
+    debug "invalid message: provided root does not belong to acceptable window of roots", provided=msg.proof.merkleRoot, validRoots=rlnPeer.validMerkleRoots.mapIt("0x" & (it.toHex))
+    waku_rln_invalid_messages_total.inc(labelValues=["invalid_root"])
   #   return MessageValidationResult.Invalid
 
   # verify the proof
@@ -1119,7 +1120,7 @@ proc mountRlnRelayDynamic*(node: WakuNode,
     # assuming all the members arrive in order
     let pk = pubkey.toIDCommitment()
     let isSuccessful = rlnPeer.insertMember(pk)
-    debug "received pk", pk=pk.toHex, index =index
+    debug "received pk", pk=pk.toHex, index=index
     debug "acceptable window", validRoots=rlnPeer.validMerkleRoots.mapIt("0x" & (it.toHex))
     doAssert(isSuccessful.isOk())
 


### PR DESCRIPTION
Does 3 things:
- Logs out when eth node connections are dropped
- Keeps track of last seen block so that when the connection is reinitiated the tree is not repopulated
- Heartbeat newHead subscription

In a follow up PR:
- Reconnection logic
