### PR TITLE
feat(rln-relay): periodically log metrics

### DIFF
--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -49,9 +49,9 @@ proc startMetricsLog*() =
       let totalErrors = parseCollectorIntoF64(waku_node_errors)
       let totalConnections = parseCollectorIntoF64(waku_node_conns_initiated)
 
-      # track cumulative, and then max.
-      let freshErrorCount = max(totalErrors - cumulativeErrors, 0)
-      let freshConnCount = max(totalConnections - cumulativeConns, 0)
+      # track cumulative values
+      let freshErrorCount = totalErrors - cumulativeErrors
+      let freshConnCount = totalConnections - cumulativeConns
       
       cumulativeErrors = totalErrors
       cumulativeConns = totalConnections
@@ -71,5 +71,6 @@ proc startMetricsLog*() =
 
   # Start protocol specific metrics logging
   when defined(rln) or defined(rlnzerokit):
-    logRlnMetrics()
+    let logRlnMetrics = getRlnMetricsLogger()
+    logRlnMetrics(nil)
   

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -41,6 +41,9 @@ proc startMetricsLog*() =
   var cumulativeErrors = 0.float64
   var cumulativeConns = 0.float64
 
+  when defined(rln) or defined(rlnzerokit):
+    let logRlnMetrics = getRlnMetricsLogger()
+
   logMetrics = proc(udata: pointer) =
     {.gcsafe.}:
       # TODO: libp2p_pubsub_peers is not public, so we need to make this either
@@ -60,12 +63,12 @@ proc startMetricsLog*() =
       info "Total errors", count = freshErrorCount
       info "Total active filter subscriptions", count = parseCollectorIntoF64(waku_filter_subscribers)
 
+      # Start protocol specific metrics logging
+      when defined(rln) or defined(rlnzerokit):
+        logRlnMetrics()
+
     discard setTimer(Moment.fromNow(30.seconds), logMetrics)
   
   discard setTimer(Moment.fromNow(30.seconds), logMetrics)
 
-  # Start protocol specific metrics logging
-  when defined(rln) or defined(rlnzerokit):
-    let logRlnMetrics = getRlnMetricsLogger()
-    logRlnMetrics(nil)
   

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -71,5 +71,5 @@ proc startMetricsLog*() =
 
   # Start protocol specific metrics logging
   when defined(rln) or defined(rlnzerokit):
-    startRlnMetricsLog()
+    logRlnMetrics()
   

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -14,7 +14,9 @@ import
   ../protocol/waku_store,
   ../protocol/waku_lightpush,
   ../protocol/waku_swap/waku_swap,
-  ../protocol/waku_peer_exchange
+  ../protocol/waku_peer_exchange,
+  ../protocol/waku_rln_relay/waku_rln_relay_metrics,
+  ../utils/collector
 
 logScope:
   topics = "wakunode.setup.metrics"
@@ -30,14 +32,7 @@ proc startMetricsServer*(serverIp: ValidIpAddress, serverPort: Port) =
 
     info "Metrics HTTP server started", serverIp, serverPort
 
-proc parseCollectorIntoF64(collector: Collector): float64 = 
-  var total = 0.float64
-  for key in collector.metrics.keys():
-    try:
-      total = total + collector.value(key)
-    except KeyError:
-      discard
-  return total
+
 
 proc startMetricsLog*() =
   # https://github.com/nim-lang/Nim/issues/17369
@@ -73,4 +68,8 @@ proc startMetricsLog*() =
     discard setTimer(Moment.fromNow(30.seconds), logMetrics)
   
   discard setTimer(Moment.fromNow(30.seconds), logMetrics)
+
+  # Start protocol specific metrics logging
+  when defined(rln) or defined(rlnzerokit):
+    startRlnMetricsLog()
   

--- a/waku/v2/node/wakunode2_setup_metrics.nim
+++ b/waku/v2/node/wakunode2_setup_metrics.nim
@@ -46,15 +46,10 @@ proc startMetricsLog*() =
       # TODO: libp2p_pubsub_peers is not public, so we need to make this either
       # public in libp2p or do our own peer counting after all.
 
-      let totalErrors = parseCollectorIntoF64(waku_node_errors)
-      let totalConnections = parseCollectorIntoF64(waku_node_conns_initiated)
-
       # track cumulative values
-      let freshErrorCount = totalErrors - cumulativeErrors
-      let freshConnCount = totalConnections - cumulativeConns
+      let freshErrorCount = parseAndAccumulate(waku_node_errors, cumulativeErrors)
+      let freshConnCount = parseAndAccumulate(waku_node_conns_initiated, cumulativeConns)
       
-      cumulativeErrors = totalErrors
-      cumulativeConns = totalConnections
       info "Total connections initiated", count = freshConnCount
       info "Total messages", count = parseCollectorIntoF64(waku_node_messages)
       info "Total swap peers", count = parseCollectorIntoF64(waku_swap_peers_count)

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics.nim
@@ -49,7 +49,7 @@ template parseAndAccumulate(collector: Collector, cumulativeValue: float64): flo
   cumulativeValue = total
   freshCount
 
-proc startRlnMetricsLog*() =
+proc logRlnMetrics*() =
   var logMetrics: proc(udata: pointer) {.gcsafe, raises: [Defect].}
 
   var cumulativeErrors = 0.float64
@@ -85,5 +85,5 @@ proc startRlnMetricsLog*() =
 
     discard setTimer(Moment.fromNow(LogPeriod.seconds), logMetrics)
   
-  discard setTimer(Moment.fromNow(LogPeriod.seconds), logMetrics)
+  logRlnMetrics()
   

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics.nim
@@ -10,9 +10,6 @@ import
 
 export metrics
 
-# Log period is measured in seconds
-const LogPeriod = 15.seconds
-
 logScope:
   topics = "waku-rln-relay.metrics"
 
@@ -44,8 +41,8 @@ declarePublicGauge(waku_rln_instance_creation_duration_seconds, "time taken to c
 declarePublicGauge(waku_rln_membership_insertion_duration_seconds, "time taken to insert a new member into the local merkle tree")
 declarePublicGauge(waku_rln_membership_credentials_import_duration_seconds, "time taken to import membership credentials")
 
-proc getRlnMetricsLogger*(): proc(udata: pointer)  =
-  var logMetrics: proc(udata: pointer) {.gcsafe, raises: [Defect].}
+proc getRlnMetricsLogger*(): proc()  =
+  var logMetrics: proc() {.gcsafe, raises: [Defect].}
 
   var cumulativeErrors = 0.float64
   var cumulativeMessages = 0.float64
@@ -54,7 +51,7 @@ proc getRlnMetricsLogger*(): proc(udata: pointer)  =
   var cumulativeValidMessages = 0.float64
   var cumulativeProofs = 0.float64
 
-  logMetrics = proc(udata: pointer) =
+  logMetrics = proc() =
     {.gcsafe.}:
 
       let freshErrorCount = parseAndAccumulate(waku_rln_errors_total,
@@ -77,7 +74,5 @@ proc getRlnMetricsLogger*(): proc(udata: pointer)  =
       info "Total valid messages", count = freshValidMsgCount
       info "Total errors", count = freshErrorCount
       info "Total proofs verified", count = freshProofCount
-
-    discard setTimer(Moment.fromNow(LogPeriod), logMetrics)
   return logMetrics
   

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics.nim
@@ -44,14 +44,6 @@ declarePublicGauge(waku_rln_instance_creation_duration_seconds, "time taken to c
 declarePublicGauge(waku_rln_membership_insertion_duration_seconds, "time taken to insert a new member into the local merkle tree")
 declarePublicGauge(waku_rln_membership_credentials_import_duration_seconds, "time taken to import membership credentials")
 
-template parseAndAccumulate(collector: Collector, cumulativeValue: float64): float64 =
-  ## This template is used to get metrics in a window 
-  ## according to a cumulative value passed in
-  let total = parseCollectorIntoF64(collector)
-  let freshCount = total - cumulativeValue
-  cumulativeValue = total
-  freshCount
-
 proc getRlnMetricsLogger*(): proc(udata: pointer)  =
   var logMetrics: proc(udata: pointer) {.gcsafe, raises: [Defect].}
 

--- a/waku/v2/utils/collector.nim
+++ b/waku/v2/utils/collector.nim
@@ -1,0 +1,11 @@
+import
+    metrics
+
+proc parseCollectorIntoF64*(collector: Collector): float64 = 
+  var total = 0.float64
+  for key in collector.metrics.keys():
+    try:
+      total = total + collector.value(key)
+    except KeyError:
+      discard
+  return total

--- a/waku/v2/utils/collector.nim
+++ b/waku/v2/utils/collector.nim
@@ -9,3 +9,11 @@ proc parseCollectorIntoF64*(collector: Collector): float64 =
     except KeyError:
       discard
   return total
+
+template parseAndAccumulate*(collector: Collector, cumulativeValue: float64): float64 =
+  ## This template is used to get metrics in a window 
+  ## according to a cumulative value passed in
+  let total = parseCollectorIntoF64(collector)
+  let freshCount = total - cumulativeValue
+  cumulativeValue = total
+  freshCount


### PR DESCRIPTION
This PR serves as the initial groundwork to allow metric logging on chat2 (https://github.com/status-im/nwaku/issues/1203)

Creates a `startRlnMetricsLog` procedure which periodically logs out certain counter-based metrics, like -
- total messages
- total spam messages
- total invalid messages
- total valid messages
- total errors
- total proofs verified

Also creates a template to avoid reuse of logic to get the metrics only for the last `period`

This proc is then imported into `wakunode_setup_metrics`, and called after.


