### PR TITLE
chore(wakucanary): resolve dns

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -37,3 +37,10 @@ $ ./build/wakucanary --address=/ip4/8.210.222.231/tcp/1000/p2p/16Uiu2HAm4v86W3bm
 $ echo $?
 1
 ```
+
+Note that a domain name can also be used.
+```console
+$ ./build/wakucanary --address=/dns4/node-01.do-ams3.status.test.statusim.net/tcp/30303/p2p/16Uiu2HAkukebeXjTQ9QDBeNDWuGfbaSg79wkkhK4vPocLgR6QFDf --protocol=store --protocol=filter
+$ echo $?
+0
+```

--- a/tools/wakucanary/wakucanary.nim
+++ b/tools/wakucanary/wakucanary.nim
@@ -6,7 +6,9 @@ import
   chronicles/topics_registry
 import
   libp2p/protocols/ping,
-  libp2p/crypto/[crypto, secp]
+  libp2p/crypto/[crypto, secp],
+  libp2p/nameresolving/nameresolver,
+  libp2p/nameresolving/dnsresolver
 import
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
@@ -81,6 +83,13 @@ proc areProtocolsSupported(
 proc main(): Future[int] {.async.} =
   let conf: WakuCanaryConf = WakuCanaryConf.load()
 
+  # create dns resolver
+  let
+    nameServers = @[
+      initTAddress(ValidIpAddress.init("1.1.1.1"), Port(53)),
+      initTAddress(ValidIpAddress.init("1.0.0.1"), Port(53))]
+    resolver: DnsResolver = DnsResolver.new(nameServers)
+
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)
 
@@ -103,7 +112,8 @@ proc main(): Future[int] {.async.} =
     node = WakuNode.new(
       nodeKey,
       ValidIpAddress.init("0.0.0.0"),
-      Port(60000))
+      Port(60000),
+      nameResolver = resolver)
 
   await node.start()
 


### PR DESCRIPTION
* Allows wakucanary tool to be used with dns names, instead of just IPs for `--address` flag.
* Related #754 #1205
* Fixes [comment](https://github.com/status-im/nwaku/pull/1205#issuecomment-1270435941)