### PR TITLE
fix: log-level being ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ endif
 # use a separate waku discv5 network with `protocol-id="d5waku"`
 NIM_PARAMS := $(NIM_PARAMS) -d:discv5_protocol_id:d5waku
 
+# enable runtime log-level filtering (see setLogLevel)
+NIM_PARAMS := $(NIM_PARAMS) -d:chronicles_runtime_filtering:on
+
 # git version for JSON RPC call
 GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
 NIM_PARAMS := $(NIM_PARAMS) -d:git_version:\"$(GIT_VERSION)\"

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -363,10 +363,15 @@ proc readInput(wfd: AsyncFD) {.thread, raises: [Defect, CatchableError].} =
 
 {.pop.} # @TODO confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError
 proc processInput(rfd: AsyncFD) {.async.} =
-  let transp = fromPipe(rfd)
+  let
+    transp = fromPipe(rfd)
+    conf = Chat2Conf.load()
+  
+  # set log level
+  if conf.logLevel != LogLevel.NONE:
+    setLogLevel(conf.logLevel)
 
   let
-    conf = Chat2Conf.load()
     (extIp, extTcpPort, extUdpPort) = setupNat(conf.nat, clientId,
       Port(uint16(conf.tcpPort) + conf.portsShift),
       Port(uint16(conf.udpPort) + conf.portsShift))

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -426,6 +426,10 @@ when isMainModule:
   if conf.version:
     echo "version / git commit hash: ", git_version
     quit(QuitSuccess)
+
+  # set log level
+  if conf.logLevel != LogLevel.NONE:
+    setLogLevel(conf.logLevel)
   
   var
     node: WakuNode  # This is the node we're going to setup using the conf

--- a/waku.nimble
+++ b/waku.nimble
@@ -65,11 +65,11 @@ task test1, "Build & run Waku v1 tests":
 ### Waku v2 tasks
 task wakunode2, "Build Waku v2 (experimental) cli node":
   let name = "wakunode2"
-  buildBinary name, "apps/wakunode2/", "-d:chronicles_log_level=DEBUG"
+  buildBinary name, "apps/wakunode2/", "-d:chronicles_log_level=TRACE"
 
 task bridge, "Build Waku v1 - v2 bridge":
   let name = "wakubridge"
-  buildBinary name, "apps/wakubridge/", "-d:chronicles_log_level=DEBUG"
+  buildBinary name, "apps/wakubridge/", "-d:chronicles_log_level=TRACE"
 
 task test2, "Build & run Waku v2 tests":
   test "all_tests_v2"
@@ -96,14 +96,14 @@ task chat2, "Build example Waku v2 chat usage":
   #buildBinary name, "examples/v2/", "-d:chronicles_log_level=WARN"
 
   let name = "chat2"
-  buildBinary name, "apps/chat2/", "-d:chronicles_log_level=DEBUG -d:chronicles_sinks=textlines[file] -d:ssl"
+  buildBinary name, "apps/chat2/", "-d:chronicles_log_level=TRACE -d:chronicles_sinks=textlines[file] -d:ssl"
 
 task chat2bridge, "Build chat2bridge":
   let name = "chat2bridge"
-  buildBinary name, "apps/chat2bridge/", "-d:chronicles_log_level=DEBUG"
+  buildBinary name, "apps/chat2bridge/", "-d:chronicles_log_level=TRACE"
 
 
 ### Waku Tooling
 task wakucanary, "Build waku-canary tool":
   let name = "wakucanary"
-  buildBinary name, "tools/wakucanary/", "-d:chronicles_log_level=DEBUG -d:chronicles_runtime_filtering:on"
+  buildBinary name, "tools/wakucanary/", "-d:chronicles_log_level=TRACE"


### PR DESCRIPTION
Closes #1197 

Problem:
* Without `-d:chronicles_runtime_filtering:on` flag `setLogLevel` does not work.
* `setLogLevel` only works with levels less verbose than `-d:chronicles_log_level=xxx`, i.e. `setLogLevel(TRACE)` won't work if `-d:chronicles_log_level=INFO`.
* More info [here](https://github.com/status-im/nwaku/issues/1197#issuecomment-1271489622).

Solution:
* Add `-d:chronicles_runtime_filtering:on` when compiling all binaries
* Set `-d:chronicles_log_level=TRACE` to all nwaku `app` and `wakunode2`

Now the following works as expected. Note that default is `INFO`.

```
$ ./build/wakunode2 --log-level=TRACE
$ ./build/wakunode2 --log-level=DEBUG
$ ./build/wakunode2 --log-level=WARN
```
