### PR TITLE
chore(store): disable temporarily the store resume flaky test case

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -13,7 +13,8 @@ import
   ./v2/test_message_store_sqlite,
   ./v2/test_waku_store_rpc_codec,
   ./v2/test_waku_store,
-  ./v2/test_waku_store_resume,
+  # TODO: Re-enable store resume test cases (#1282)
+  # ./v2/test_waku_store_resume,
   ./v2/test_wakunode_store,
   # Waku Filter
   ./v2/test_waku_filter,


### PR DESCRIPTION
As the test has been failing for a month, causing many inconveniences, no clear root cause has been identified so far, and the resume store is a second-priority functionality; this PR disables it temporarily, and the following issue has been created to track the investigation/fix:

- #1282