### PR TITLE
chore: extract test procedures and constants into a common module

### DIFF
--- a/tests/v2/test_message_cache.nim
+++ b/tests/v2/test_message_cache.nim
@@ -6,16 +6,10 @@ import
   chronicles
 import
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/node/message_cache
+  ../../waku/v2/node/message_cache,
+  ./testlib/common
 
 
-proc fakeWakuMessage(payload = toBytes("TEST"), contentTopic = "test"): WakuMessage = 
-  WakuMessage(
-    payload: payload,
-    contentTopic: contentTopic,
-    version: 1,
-    timestamp: 2022
-  )
 
 type PubsubTopicString = string
 

--- a/tests/v2/test_message_store_queue_index.nim
+++ b/tests/v2/test_message_store_queue_index.nim
@@ -8,12 +8,8 @@ import
 import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/utils/time,
-  ../../waku/v2/node/storage/message/queue_store/index
-
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
+  ../../waku/v2/node/storage/message/queue_store/index,
+  ./testlib/common
 
 
 ## Helpers

--- a/tests/v2/test_message_store_queue_pagination.nim
+++ b/tests/v2/test_message_store_queue_pagination.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options, sequtils, times, algorithm],
+  std/[options, sequtils, algorithm],
   testutils/unittests, 
   nimcrypto/sha2,
   libp2p/protobuf/minprotobuf
@@ -9,12 +9,8 @@ import
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/utils/time
-
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
+  ../../waku/v2/utils/time,
+  ./testlib/common
 
 
 proc getTestStoreQueue(numMessages: int): StoreQueueRef =
@@ -35,12 +31,6 @@ proc getTestStoreQueue(numMessages: int): StoreQueueRef =
     discard testStoreQueue.add(msg)
   
   return testStoreQueue
-
-proc now(): Timestamp = 
-  getNanosecondTime(getTime().toUnixFloat())
-
-proc ts(offset=0, origin=now()): Timestamp =
-  origin + getNanosecondTime(offset)
 
 
 suite "Queue store - pagination":

--- a/tests/v2/test_message_store_sqlite.nim
+++ b/tests/v2/test_message_store_sqlite.nim
@@ -13,34 +13,12 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store/pagination,
   ../../waku/v2/utils/time,
-  ./utils
-
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
+  ./utils,
+  ./testlib/common
 
 
 proc newTestDatabase(): SqliteDatabase =
   SqliteDatabase.init("", inMemory = true).tryGet()
-
-proc now(): Timestamp =
-  getNanosecondTime(getTime().toUnixFloat())
-
-proc ts(offset=0, origin=now()): Timestamp = 
-  origin + getNanosecondTime(offset)
-
-proc fakeWakuMessage(
-  payload = "TEST-PAYLOAD",
-  contentTopic = DefaultContentTopic, 
-  ts = now()
-): WakuMessage = 
-  WakuMessage(
-    payload: toBytes(payload),
-    contentTopic: contentTopic,
-    version: 1,
-    timestamp: ts
-  )
 
 
 suite "SQLite message store - init store":

--- a/tests/v2/test_message_store_sqlite_query.nim
+++ b/tests/v2/test_message_store_sqlite_query.nim
@@ -1,44 +1,22 @@
 {.used.}
 
 import
-  std/[options, tables, sets, times, strutils, sequtils, algorithm],
-  stew/byteutils,
+  std/[options, tables, sets, strutils, sequtils, algorithm],
   unittest2,
   chronos,
-  chronicles,
+  chronicles
+import
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/storage/sqlite,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store/pagination,
   ../../waku/v2/utils/time,
-  ./utils
+  ./utils,
+  ./testlib/common
 
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
-
-
-proc now(): Timestamp =
-  getNanosecondTime(getTime().toUnixFloat())
-
-proc ts(offset=0, origin=now()): Timestamp =
-  origin + getNanosecondTime(offset)
 
 proc newTestDatabase(): SqliteDatabase =
   SqliteDatabase.init("", inMemory = true).tryGet()
-
-proc fakeWakuMessage(
-  payload = "TEST-PAYLOAD",
-  contentTopic = DefaultContentTopic, 
-  ts = now()
-): WakuMessage = 
-  WakuMessage(
-    payload: toBytes(payload),
-    contentTopic: contentTopic,
-    version: 1,
-    timestamp: ts
-  )
 
 
 suite "message store - history query":
@@ -477,7 +455,7 @@ suite "message store - history query":
   test "single content topic and valid time range":
     ## Given
     const contentTopic = "test-content-topic"
-    let timeOrigin = getNanosecondTime(epochTime())
+    let timeOrigin = now()
 
     let 
       database = newTestDatabase()
@@ -522,7 +500,7 @@ suite "message store - history query":
   test "single content topic and invalid time range - no results":
     ## Given
     const contentTopic = "test-content-topic"
-    let timeOrigin = getNanosecondTime(epochTime())
+    let timeOrigin = now()
 
     let 
       database = newTestDatabase()
@@ -561,7 +539,7 @@ suite "message store - history query":
   test "single content topic and only time range start":
     ## Given
     const contentTopic = "test-content-topic"
-    let timeOrigin = getNanosecondTime(epochTime())
+    let timeOrigin = now()
 
     let 
       database = newTestDatabase()
@@ -602,7 +580,7 @@ suite "message store - history query":
   test "single content topic, cursor and only time range start":
     ## Given
     const contentTopic = "test-content-topic"
-    let timeOrigin = getNanosecondTime(epochTime())
+    let timeOrigin = now()
 
     let 
       database = newTestDatabase()

--- a/tests/v2/test_rest_relay_api.nim
+++ b/tests/v2/test_rest_relay_api.nim
@@ -13,7 +13,9 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/node/rest/[server, client, base64, utils],
-  ../../waku/v2/node/rest/relay/[api_types, relay_api, topic_cache]
+  ../../waku/v2/node/rest/relay/[api_types, relay_api, topic_cache],
+  ../../waku/v2/utils/time,
+  ./testlib/common
 
 
 proc testWakuNode(): WakuNode = 
@@ -25,14 +27,6 @@ proc testWakuNode(): WakuNode =
     port = Port(9000)
 
   WakuNode.new(privkey, bindIp, port, some(extIp), some(port))
-
-proc fakeWakuMessage(payload = toBytes("TEST"), contentTopic = "test"): WakuMessage = 
-  WakuMessage(
-    payload: payload,
-    contentTopic: contentTopic,
-    version: 1,
-    timestamp: 2022
-  )
 
 
 suite "REST API - Relay":
@@ -167,8 +161,8 @@ suite "REST API - Relay":
       response.data.all do (msg: RelayWakuMessage) -> bool: 
         msg.payload == Base64String.encode("TEST-1") and
         msg.contentTopic.get().string == "content-topic-x" and
-        msg.version.get() == Natural(1) and
-        msg.timestamp.get() == int64(2022)
+        msg.version.get() == 2 and
+        msg.timestamp.get() != Timestamp(0)
 
 
     check:

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -5,7 +5,6 @@ import
   testutils/unittests,
   chronos, 
   chronicles,
-  libp2p/switch,
   libp2p/crypto/crypto,
   libp2p/multistream
 import
@@ -13,19 +12,12 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_filter,
   ../test_helpers, 
-  ./utils
+  ./utils,
+  ./testlib/common,
+  ./testlib/switch
 
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
 
 const dummyHandler = proc(requestId: string, msg: MessagePush) {.async, gcsafe, closure.} = discard
-
-proc newTestSwitch(key=none(PrivateKey), address=none(MultiAddress)): Switch =
-  let peerKey = key.get(PrivateKey.random(ECDSA, rng[]).get())
-  let peerAddr = address.get(MultiAddress.init("/ip4/127.0.0.1/tcp/0").get()) 
-  return newStandardSwitch(some(peerKey), addrs=peerAddr)
 
 
 # TODO: Extend test coverage

--- a/tests/v2/test_waku_lightpush.nim
+++ b/tests/v2/test_waku_lightpush.nim
@@ -11,12 +11,8 @@ import
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_lightpush,
-  ../test_helpers
-
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
+  ../test_helpers,
+  ./testlib/common
 
 
 # TODO: Extend lightpush protocol test coverage

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -6,7 +6,8 @@ import
   testutils/unittests, chronos, chronicles, stint,
   stew/byteutils, stew/shims/net as stewNet,
   libp2p/crypto/crypto,
-  json,
+  json
+import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_rln_relay/[rln, 
       waku_rln_relay_utils,

--- a/tests/v2/test_waku_store_rpc_codec.nim
+++ b/tests/v2/test_waku_store_rpc_codec.nim
@@ -9,24 +9,8 @@ import
 import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store,
-  ../../waku/v2/utils/time
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
-
-
-proc fakeWakuMessage(
-  payload = "TEST-PAYLOAD",
-  contentTopic = DefaultContentTopic, 
-  ts = getNanosecondTime(epochTime())
-): WakuMessage = 
-  WakuMessage(
-    payload: toBytes(payload),
-    contentTopic: contentTopic,
-    version: 1,
-    timestamp: ts
-  )
+  ../../waku/v2/utils/time,
+  ./testlib/common
 
 
 procSuite "Waku Store - RPC codec":

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -22,28 +22,8 @@ import
   ../../waku/v2/utils/peers,
   ../../waku/v2/utils/time,
   ../test_helpers, 
-  ./utils
-
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
-
-
-proc now(): Timestamp = 
-  getNanosecondTime(getTime().toUnixFloat())
-
-proc fakeWakuMessage(
-  payload = "TEST-PAYLOAD",
-  contentTopic = DefaultContentTopic, 
-  ts = now()
-): WakuMessage = 
-  WakuMessage(
-    payload: toBytes(payload),
-    contentTopic: contentTopic,
-    version: 1,
-    timestamp: ts
-  )
+  ./utils,
+  ./testlib/common
 
 
 procSuite "Waku SWAP Accounting":

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -7,35 +7,14 @@ import
   chronicles, 
   chronos, 
   libp2p/crypto/crypto,
-  libp2p/switch,
+  libp2p/switch
+import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
-  ../../waku/v2/utils/time,
-  ../../waku/v2/node/waku_node
-
-from std/times import getTime, toUnixFloat
-
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
-
-proc now(): Timestamp = 
-  getNanosecondTime(getTime().toUnixFloat())
-
-proc fakeWakuMessage(
-  payload = "TEST-PAYLOAD",
-  contentTopic = DefaultContentTopic, 
-  ts = now()
-): WakuMessage = 
-  WakuMessage(
-    payload: toBytes(payload),
-    contentTopic: contentTopic,
-    version: 1,
-    timestamp: ts
-  )
+  ../../waku/v2/node/waku_node,
+  ./testlib/common
 
 
 procSuite "WakuNode - Lightpush":

--- a/tests/v2/test_wakunode_relay.nim
+++ b/tests/v2/test_wakunode_relay.nim
@@ -16,7 +16,7 @@ import
   libp2p/protocols/pubsub/pubsub,
   libp2p/protocols/pubsub/gossipsub
 import
-  ../../waku/v2/protocol/[waku_relay, waku_message],
+  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
   ../../waku/v2/node/waku_node

--- a/tests/v2/test_wakunode_store.nim
+++ b/tests/v2/test_wakunode_store.nim
@@ -23,33 +23,13 @@ import
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
   ../../waku/v2/utils/time,
-  ../../waku/v2/node/waku_node
+  ../../waku/v2/node/waku_node,
+  ./testlib/common
 
-from std/times import getTime, toUnixFloat
-
-
-const 
-  DefaultPubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic = ContentTopic("/waku/2/default-content/proto")
-
-proc now(): Timestamp = 
-  getNanosecondTime(getTime().toUnixFloat())
 
 proc newTestMessageStore(): MessageStore =
   let database = SqliteDatabase.init("", inMemory = true)[]
   SqliteStore.init(database).tryGet()
-
-proc fakeWakuMessage(
-  payload = "TEST-PAYLOAD",
-  contentTopic = DefaultContentTopic, 
-  ts = now()
-): WakuMessage = 
-  WakuMessage(
-    payload: toBytes(payload),
-    contentTopic: contentTopic,
-    version: 1,
-    timestamp: ts
-  )
 
 
 procSuite "WakuNode - Store":
@@ -199,7 +179,7 @@ procSuite "WakuNode - Store":
 
     # Insert the same message in both node's store
     let 
-      receivedTime3 = getNanosecondTime(getTime().toUnixFloat() + 10.float)
+      receivedTime3 = now() + getNanosecondTime(10)
       digest3 = computeDigest(msg3)
     require server.wakuStore.store.put(DefaultTopic, msg3, digest3, receivedTime3).isOk()
     require client.wakuStore.store.put(DefaultTopic, msg3, digest3, receivedTime3).isOk()

--- a/tests/v2/testlib/common.nim
+++ b/tests/v2/testlib/common.nim
@@ -1,0 +1,38 @@
+import
+  std/times
+import
+  ../../../waku/v2/protocol/waku_message,
+  ../../../waku/v2/utils/time
+
+const 
+  DefaultPubsubTopic* = "/waku/2/default-waku/proto"
+  DefaultContentTopic* = ContentTopic("/waku/2/default-content/proto")
+
+
+proc now*(): Timestamp =
+  getNanosecondTime(getTime().toUnixFloat())
+
+proc ts*(offset=0, origin=now()): Timestamp =
+  origin + getNanosecondTime(offset)
+
+
+proc fakeWakuMessage*(
+  payload: string|seq[byte] = "TEST-PAYLOAD",
+  contentTopic = DefaultContentTopic, 
+  ts = now(),
+  ephemeral = false
+): WakuMessage = 
+  var payloadBytes: seq[byte]
+  when payload is string:
+    payloadBytes = toBytes(payload)
+  else:
+    payloadBytes = payload
+
+  WakuMessage(
+    payload: payloadBytes,
+    contentTopic: contentTopic,
+    version: 2,
+    timestamp: ts,
+    ephemeral: ephemeral
+  )
+  

--- a/tests/v2/testlib/switch.nim
+++ b/tests/v2/testlib/switch.nim
@@ -1,0 +1,11 @@
+import
+  std/options,
+  libp2p/switch,
+  libp2p/builders
+import
+  ../../test_helpers
+
+proc newTestSwitch*(key=none(PrivateKey), address=none(MultiAddress)): Switch =
+  let peerKey = key.get(PrivateKey.random(ECDSA, rng[]).get())
+  let peerAddr = address.get(MultiAddress.init("/ip4/127.0.0.1/tcp/0").get()) 
+  return newStandardSwitch(some(peerKey), addrs=peerAddr)


### PR DESCRIPTION
These changes move all the common test helpers under `testlib` folder.

This PR resolves #1173 