### PR TITLE
chore(networkmonitor): tool to discover and provide metrics on peers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,9 @@ wakucanary: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim wakucanary $(NIM_PARAMS) waku.nims
 
+networkmonitor: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim networkmonitor $(NIM_PARAMS) waku.nims
 
 ## Waku docs
 

--- a/tests/v2/test_enr_utils.nim
+++ b/tests/v2/test_enr_utils.nim
@@ -125,3 +125,5 @@ procSuite "ENR utils":
     
     for knownMultiaddr in knownMultiaddrs:
       check decodedAddrs.contains(knownMultiaddr)
+
+# TODO: Add new test for supportsCapability()

--- a/tests/v2/test_enr_utils.nim
+++ b/tests/v2/test_enr_utils.nim
@@ -1,10 +1,10 @@
 {.used.}
 
 import
-  testutils/unittests,
   std/[options,sequtils],
-  stew/byteutils,
   chronos,
+  stew/byteutils,
+  testutils/unittests,
   ../../waku/v2/utils/wakuenr,
   ../test_helpers
 

--- a/tests/v2/test_enr_utils.nim
+++ b/tests/v2/test_enr_utils.nim
@@ -126,40 +126,25 @@ procSuite "ENR utils":
     for knownMultiaddr in knownMultiaddrs:
       check decodedAddrs.contains(knownMultiaddr)
 
-  asyncTest "Supports capabilities encoded in the ENR":
+  asyncTest "Supports specific capabilities encoded in the ENR":
     let
       enrIp = ValidIpAddress.init("127.0.0.1")
       enrTcpPort, enrUdpPort = Port(60000)
       enrKey = wakuenr.crypto.PrivateKey.random(Secp256k1, rng[])[]
       multiaddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/442/ws")[]]
       
-      # TODO: ugly, refactor
-      records = @[initWakuFlags(false, false, false, false),
-                  initWakuFlags(false, false, false, true),
-                  initWakuFlags(false, false, true, false),
-                  initWakuFlags(false, false, true, true),
-                  initWakuFlags(false, true, false, false),
-                  initWakuFlags(false, true, false, true),
-                  initWakuFlags(false, true, true, false),
-                  initWakuFlags(false, true, true, true),
-                  initWakuFlags(true, false, false, false),
-                  initWakuFlags(true, false, false, true),
-                  initWakuFlags(true, false, true, false),
-                  initWakuFlags(true, false, true, true),
-                  initWakuFlags(true, true, false, false),
-                  initWakuFlags(true, true, false, true),
-                  initWakuFlags(true, true, true, false),
-                  initWakuFlags(true, true, true, true)]
-                  .mapIt(initEnr(enrKey,
-                                 some(enrIp),
-                                 some(enrTcpPort),
-                                 some(enrUdpPort),
-                                 some(it),
-                                 multiaddrs))
+      # TODO: Refactor initEnr, provide enums as inputs initEnr(capabilites=[Store,Filter])
+      # TODO: safer than a util function and directly using the bits
+      # test all flag combinations 2^4 = 16 (b0000-b1111)
+      records = toSeq(0b0000_0000'u8..0b0000_1111'u8)
+                        .mapIt(initEnr(enrKey,
+                                       some(enrIp),
+                                       some(enrTcpPort),
+                                       some(enrUdpPort),
+                                       some(uint8(it)),
+                                       multiaddrs))
 
-      # pitty the wakuFlags arguments can't be unwrapped
       # same order:         lightpush | filter| store | relay
-      # TODO: Refactor after changing initWakuFlags. ask team
       expectedCapabilities = @[[false, false, false, false],
                                [false, false, false, true],
                                [false, false, true, false],
@@ -180,3 +165,53 @@ procSuite "ENR utils":
     for i, record in records:
       for j, capability in @[Lightpush, Filter, Store, Relay]:
         check expectedCapabilities[i][j] == record.supportsCapability(capability)
+
+  asyncTest "Get all supported capabilities encoded in the ENR":
+    let
+      enrIp = ValidIpAddress.init("127.0.0.1")
+      enrTcpPort, enrUdpPort = Port(60000)
+      enrKey = wakuenr.crypto.PrivateKey.random(Secp256k1, rng[])[]
+      multiaddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/442/ws")[]]
+      
+      records = @[0b0000_0000'u8,
+                  0b0000_1111'u8,
+                  0b0000_1001'u8,
+                  0b0000_1110'u8,
+                  0b0000_1000'u8,]
+                  .mapIt(initEnr(enrKey,
+                                 some(enrIp),
+                                 some(enrTcpPort),
+                                 some(enrUdpPort),
+                                 some(uint8(it)),
+                                 multiaddrs))
+
+      # expected capabilities, ordered LSB to MSB
+      expectedCapabilities: seq[seq[Capabilities]] = @[
+      #[0b0000_0000]#          @[],
+      #[0b0000_1111]#          @[Relay, Store, Filter, Lightpush],
+      #[0b0000_1001]#          @[Relay, Lightpush],
+      #[0b0000_1110]#          @[Store, Filter, Lightpush],
+      #[0b0000_1000]#          @[Lightpush]]
+
+    for i, actualExpetedTuple in zip(records, expectedCapabilities):
+      check actualExpetedTuple[0].getCapabilities() == actualExpetedTuple[1]
+
+  asyncTest "Get supported capabilities of a non waku node":
+    
+    # non waku enr, i.e. Ethereum one 
+    let nonWakuEnr = "enr:-KG4QOtcP9X1FbIMOe17QNMKqDxCpm14jcX5tiOE4_TyMrFqbmhPZHK_ZPG2G"&
+    "xb1GE2xdtodOfx9-cgvNtxnRyHEmC0ghGV0aDKQ9aX9QgAAAAD__________4JpZIJ2NIJpcIQDE8KdiXNl"&
+    "Y3AyNTZrMaEDhpehBDbZjM_L9ek699Y7vhUJ-eAdMyQW_Fil522Y0fODdGNwgiMog3VkcIIjKA"
+    
+    var nonWakuEnrRecord: Record
+    
+    check:
+      nonWakuEnrRecord.fromURI(nonWakuEnr)
+
+    # check that it doesn't support any capability and it doesnt't break
+    check:
+      nonWakuEnrRecord.getCapabilities() == []
+      nonWakuEnrRecord.supportsCapability(Relay) == false
+      nonWakuEnrRecord.supportsCapability(Store) == false
+      nonWakuEnrRecord.supportsCapability(Filter) == false
+      nonWakuEnrRecord.supportsCapability(Lightpush) == false

--- a/tools/README.md
+++ b/tools/README.md
@@ -54,6 +54,7 @@ Monitoring tool to run in an existing `waku` network with the following features
 * Tracks advertised capabilities of each node as per stored in the ENR `waku` field
 * Attempts to connect to all nodes, tracking which protocols each node supports
 * Presents grafana-ready metrics showing the state of the network in terms of locations, ips, number discovered peers, number of peers we could connect to, user-agent that each peer contains, etc.
+* Metrics are exposed through prometheus metrics but also with a custom rest api, presenting detailed information about each peer.
 
 ### Usage
 
@@ -72,6 +73,8 @@ The following options are available:
      --metrics-server          Enable the metrics server: true|false [=true].
      --metrics-server-address  Listening address of the metrics server. [=ValidIpAddress.init("127.0.0.1")].
      --metrics-server-port     Listening HTTP port of the metrics server. [=8008].
+     --metrics-rest-address    Listening address of the metrics rest server. [=127.0.0.1].
+     --metrics-rest-port       Listening HTTP port of the metrics rest server. [=8009].
 ```
 
 ### Example
@@ -85,14 +88,16 @@ Connect to the network through a given bootstrap node, with default parameters. 
 
 ### metrics
 
-The following metrics are available:
+The following metrics are available. See `http://localhost:8008/metrics`
 
 * peer_type_as_per_enr: Number of peers supporting each capability according the the ENR (Relay, Store, Lightpush, Filter)
 * peer_type_as_per_protocol: Number of peers supporting each protocol, after a successful connection)
-* discovered_peers_list: List of discovered peers with extra information on each of them
-* connected_peers_list: List of peers that we connected to with extra information on each one
 * peer_user_agents: List of useragents found in the network and their count
 
 Other relevant metrics reused from `nim-eth`:
 * routing_table_nodes: Inherited from nim-eth, number of nodes in the routing table
 * discovery_message_requests_outgoing_total: Inherited from nim-eth, number of outging discovery requests, useful to know if the node is actiely looking for new peers
+
+The following metrics are exposed via a custom rest api. See `http://localhost:8009/allpeersinfo`
+
+* json list of all peers with extra information such as ip, locatio, supported protocols and last connection time.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,4 +1,4 @@
-## waku canary tool
+## waku canary tool
 
 Attempts to dial a peer and asserts it supports a given set of protocols.
 
@@ -46,3 +46,51 @@ $ ./build/wakucanary --address=/dns4/node-01.do-ams3.status.test.statusim.net/tc
 $ echo $?
 0
 ```
+
+## networkmonitor
+
+Monitoring tool to run in an existing `waku` network with the following features:
+* Keeps discovering new peers using `discv5`
+* Tracks advertised capabilities of each node as per stored in the ENR `waku` field
+* Attempts to connect to all nodes, tracking which protocols each node supports
+* Presents grafana-ready metrics showing the state of the network in terms of locations, ips, number discovered peers, number of peers we could connect to, user-agent that each peer contains, etc.
+
+### Usage
+
+```console
+./build/networkmonitor --help
+Usage:
+
+networkmonitor [OPTIONS]...
+
+The following options are available:
+
+ -l, --log-level               Sets the log level [=LogLevel.DEBUG].
+ -t, --timeout                 Timeout to consider that the connection failed [=chronos.seconds(10)].
+ -b, --bootstrap-node          Bootstrap ENR node. Argument may be repeated. [=@[""]].
+ -r, --refresh-interval        How often new peers are discovered and connected to (in minutes) [=10].
+     --metrics-server          Enable the metrics server: true|false [=true].
+     --metrics-server-address  Listening address of the metrics server. [=ValidIpAddress.init("127.0.0.1")].
+     --metrics-server-port     Listening HTTP port of the metrics server. [=8008].
+```
+
+### Example
+
+Connect to the network through a given bootstrap node, with default parameters. Once its running, metrics will be live at `localhost:8008/metrics`
+
+```console
+./build/networkmonitor --log-level=INFO --b="enr:-Nm4QOdTOKZJKTUUZ4O_W932CXIET-M9NamewDnL78P5u9DOGnZlK0JFZ4k0inkfe6iY-0JAaJVovZXc575VV3njeiABgmlkgnY0gmlwhAjS3ueKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuYWMtY24taG9uZ2tvbmctYy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhAo0C-VvfgHiXrxZi3umDiooXMGY9FvYj5_d1Q4EeS7eyg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP"
+```
+
+
+### metrics
+
+The following metrics are available:
+
+* peer_type_as_per_enr: Number of peers supporting each capability according the the ENR (Relay, Store, Lightpush, Filter)
+* peer_type_as_per_protocol: Number of peers supporting each protocol, after a successful connection)
+* discovered_peers_list: List of discovered peers with extra information on each of them
+* connected_peers_list: List of peers that we connected to with extra information on each one
+* routing_table_nodes: Inherited from nim-eth, number of nodes in the routing table
+* discovery_message_requests_outgoing_total: Inherited from nim-eth, number of outging discovery requests, useful to know if the node is actiely looking for new peers
+* TODO: client diversity:

--- a/tools/README.md
+++ b/tools/README.md
@@ -91,6 +91,8 @@ The following metrics are available:
 * peer_type_as_per_protocol: Number of peers supporting each protocol, after a successful connection)
 * discovered_peers_list: List of discovered peers with extra information on each of them
 * connected_peers_list: List of peers that we connected to with extra information on each one
+* peer_user_agents: List of useragents found in the network and their count
+
+Other relevant metrics reused from `nim-eth`:
 * routing_table_nodes: Inherited from nim-eth, number of nodes in the routing table
 * discovery_message_requests_outgoing_total: Inherited from nim-eth, number of outging discovery requests, useful to know if the node is actiely looking for new peers
-* TODO: client diversity:

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -1,10 +1,9 @@
 import
   confutils,
-  std/[sugar,tables,strutils,times,sequtils],
+  std/[tables,strutils,times,sequtils],
   chronicles,
   chronicles/topics_registry,
   chronos,
-  stew/byteutils,
   stew/shims/net,
   metrics,
   metrics/chronos_httpserver,
@@ -13,7 +12,6 @@ import
   eth/p2p/discoveryv5/enr
 
 import
-  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/discv5/waku_discv5,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/wakunode2,
@@ -179,11 +177,10 @@ proc main() {.async.} =
     # populate metrics related to capabilities as advertised by the ENR (see waku field)
     setDiscoveredPeersCapabilities(flatNodes)
 
-    # TODO: as this can't scale with thousands of peers,
-    # we would need to connect to just newly discovered nodes.
-    # tries to connect to all peers in the routing table
-    # populate metrics related to peers we could connect
-    await setConnectedPeersMetrics(flatNodes, node, conf.timeout)
+    # tries to connect to all newly discovered nodes
+    # and populates metrics related to peers we could connect
+    # note random discovered nodes can be already known
+    await setConnectedPeersMetrics(discoveredNodes, node, conf.timeout)
 
     let totalNodes = flatNodes.len
     let seenNodes = flatNodes.countIt(it.seen)

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -1,31 +1,39 @@
+# TODO: fix imports
 import
   confutils,
+  sequtils,
+  std/sugar,
   std/tables,
   chronicles,
   chronicles/topics_registry,
   chronos,
   stew/byteutils,
   stew/shims/net,
+  metrics,
+  metrics/chronos_httpserver,
   libp2p/crypto/crypto,
   eth/keys,
   eth/p2p/discoveryv5/enr,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/discv5/waku_discv5,
   ../../waku/v2/node/wakunode2,
-  eth/keys
+  ../../waku/v2/utils/wakuenr,
+  networkmonitor_metrics,
+  networkmonitor_config
 
-type
-  NetworkMonitorConf* = object
-    logLevel* {.
-      desc: "Sets the log level",
-      defaultValue: LogLevel.DEBUG,
-      name: "log-level",
-      abbr: "l" .}: LogLevel
+logScope:
+  topics = "networkmonitor"
 
 proc main() {.async.} = 
   let conf: NetworkMonitorConf = NetworkMonitorConf.load()
+
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)
+
+  if conf.metricsServer:
+    startMetricsServer(
+      conf.metricsServerAddress,
+      Port(conf.metricsServerPort))
 
   let
     rng = keys.newRng()
@@ -34,7 +42,7 @@ proc main() {.async.} =
     nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
     nodeTcpPort1 = Port(60000)
     nodeUdpPort1 = Port(9000)
-    node1 = WakuNode.new(
+    node = WakuNode.new(
       nodeKey1,
       bindIp,
       nodeTcpPort1)
@@ -43,16 +51,25 @@ proc main() {.async.} =
                           filter = false,
                           store = false,
                           relay = true)
+
+
+                        
+  # TODO: use other discovery mechanisms
   
   # waku prod bootstrap nodes
   const bootstrapNodes = @[
-    "enr:-JK4QPZWoojZJFRRxV87plIci5aaZMKaTs2YvvmCP7e0TGZPIxKWlkVExJc7xtdjUFw-SRj69FTul25o2uY2akaKpEcBgmlkgnY0gmlwhAjS3ueJc2VjcDI1NmsxoQKNAvlb34B4l68WYt7pg4qKFzBmPRb2I-f3dUOBHku3soN0Y3CCdl-DdWRwgiMohXdha3UyDw",
-    "enr:-JK4QIJuHZHTCaUOOwupvl7e3K1DyeDI6a609YJKdlovKj0pQa66P-2lMCw5oYUD-veYl0NNLW2CYHLYrC9CmZqDTLEBgmlkgnY0gmlwhLymh5GJc2VjcDI1NmsxoQNuXVf_MkjDcQAka2YcxWfhnbGGlKhRo_kSWwcoK_uGVYN0Y3CCdl-DdWRwgiMohXdha3UyDw",
-    "enr:-JK4QOgn2QQHSJCaLUZuxghlFL92VgL2eEd8LOyiYF0jyEkQUlH1KoOnPdcrO39qggSOsWECPWrO8GewdZmKhlvnHhQBgmlkgnY0gmlwhCJ5ZGyJc2VjcDI1NmsxoQP99JB4EKn12UYqGuCf7uWrIF0yeYsP_MN5RCAh-Exbv4N0Y3CCdl-DdWRwgiMohXdha3UyDw",
+    # prod
+    "enr:-Nm4QOdTOKZJKTUUZ4O_W932CXIET-M9NamewDnL78P5u9DOGnZlK0JFZ4k0inkfe6iY-0JAaJVovZXc575VV3njeiABgmlkgnY0gmlwhAjS3ueKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuYWMtY24taG9uZ2tvbmctYy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhAo0C-VvfgHiXrxZi3umDiooXMGY9FvYj5_d1Q4EeS7eyg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP",
+    "enr:-M-4QLdAB-KyzT3QEsDoNa4LXT6RGH9BIylvTlDFLQhigWmxKEesulgc8AoKmVEUKj_4St6ThBKwyBc69tBfCe2hVTABgmlkgnY0gmlwhLymh5GKbXVsdGlhZGRyc7EALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi5wcm9kLnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDbl1X_zJIw3EAJGtmHMVn4Z2xhpSoUaP5ElsHKCv7hlWDdGNwgnZfg3VkcIIjKIV3YWt1Mg8",
+    "enr:-Nm4QNgc2L6L-4nk6jgllNDE1QDcn6kv2922rTRYs1wM3My_OmSsTimkMCIMh8fat6enFdYfuJ23KjWdF5whBz3zXgUBgmlkgnY0gmlwhCJ5ZGyKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuZ2MtdXMtY2VudHJhbDEtYS53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhA_30kHgQqfXZRioa4J_u5asgXTJ5iw_8w3lEICH4TFu_g3RjcIJ2X4N1ZHCCIyiFd2FrdTIP",
+    # test
+    "enr:-Nm4QC0_ClHzbsutYzgT3jJm7ZY1D4shylAdd6Ac-L4uwAUha1oHM0zwoEkTORVt94W5Cpa0IiyrTcXAYLgpRXpVNUsBgmlkgnY0gmlwhC_y0kmKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuYWMtY24taG9uZ2tvbmctYy53YWt1djIudGVzdC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhAhAm-P4q6mWONKcGnbLPU8WXZJ4Qs3AxIbrycvc7PVKsg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP",
+    "enr:-M-4QCtJKX2WDloRYDT4yjeMGKUCRRcMlsNiZP3cnPO0HZn6IdJ035RPCqsQ5NvTyjqHzKnTM6pc2LoKliV4CeV0WrgBgmlkgnY0gmlwhIbRi9KKbXVsdGlhZGRyc7EALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi50ZXN0LnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDnr03Tuo77930a7sYLikftxnuG3BbC3gCFhA4632ooDaDdGNwgnZfg3VkcIIjKIV3YWt1Mg8",
+    "enr:-Nm4QLHYoJ5WYQoVzyqPR-pwIeQvi3ONWs-EPwk3uUiBiDseN9Dd7fYbCvkMdeXcuZ-8U9IYdGm38VxSDf_Oq3zZ0cEBgmlkgnY0gmlwhGia74CKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuZ2MtdXMtY2VudHJhbDEtYS53YWt1djIudGVzdC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhA1giYsmWV9r2yJZYAiMGHJfjLlLeqAuTAokUGPN__pkxg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP",
   ]
   
   # mount discv5
-  node1.wakuDiscv5 = WakuDiscoveryV5.new(
+  node.wakuDiscv5 = WakuDiscoveryV5.new(
       some(extIp), some(nodeTcpPort1), some(nodeUdpPort1),
       bindIp,
       nodeUdpPort1,
@@ -61,22 +78,41 @@ proc main() {.async.} =
       keys.PrivateKey(nodeKey1.skkey),
       flags,
       [], # Empty enr fields, for now
-      node1.rng
+      node.rng
     )
-  await node1.mountRelay()
-  await allFutures([node1.start()])
-  await allFutures([node1.startDiscv5()])
+  #await node.mountRelay()
+  #await allFutures([node.start()])
 
+  # TODO remove thi. Note that now it doesnt work with it
+  await allFutures([node.startDiscv5()]) 
+  let d = node.wakuDiscv5.protocol
   while true:
-    let discoveredPeers = await node1.wakuDiscv5.findRandomPeers()
-    echo node1.wakuDiscv5.protocol.nodesDiscovered
-    for bucket in node1.wakuDiscv5.protocol.routingTable.buckets:
+    # we dont care about the result, everything is updated inside the routingTable
+    discard await d.queryRandom()
+
+    for bucket in d.routingTable.buckets:
       for node in bucket.nodes:
-        echo "id", node.id
-        echo "pubkey", node.pubkey
-        echo "address", node.address
-        echo "seen", node.seen
-        echo "record", node.record
+        #echo "id", node.id
+        #echo "pubkey", node.pubkey
+        #echo "address", node.address
+        #echo "seen", node.seen
+        #echo "pairs", node.record
+        for capability in @[Relay, Store, Filter, Lightpush]:
+          if node.record.supportsCapability(capability):
+            echo "node:", node.address, " supports ", capability
+            # TODO: add to prometheus metrics
+    
+    let totalNodes = d.routingTable.buckets.foldl(a + b.nodes.len, 0)
+    let seenNodes = d.routingTable.buckets.foldl(a + b.nodes.filterIt(it.seen == true).len, 0)
+
+    echo "total nodes: ", totalNodes
+    echo "seen nodes: ", seenNodes
+
+    # TODO: we dont run ipMajorityLoop
+    # TODO: we dont run revalidateLoop to not empty the routing table
+    # TODO: connect to nodes to see the protocol they actually support
+
+    # TODO: flag for how aggresive
     await sleepAsync(5000)
 
 when isMainModule:

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -1,8 +1,6 @@
-# TODO: fix imports
 import
   confutils,
-  sequtils,
-  std/[sugar,tables,strutils,times],
+  std/[sugar,tables,strutils,times,sequtils],
   chronicles,
   chronicles/topics_registry,
   chronos,
@@ -22,16 +20,11 @@ import
   ../../waku/v2/utils/wakuenr,
   ../../waku/v2/utils/peers,
   ./networkmonitor_metrics,
-  ./networkmonitor_config
+  ./networkmonitor_config,
+  ./networkmonitor_utils
 
 logScope:
   topics = "networkmonitor"
-        
-# TODO: Move to utils
-proc flatten*[T](a: seq[seq[T]]): seq[T] =
-  result = @[]
-  for subseq in a:
-    result &= subseq
 
 proc setDiscoveredPeersMetrics(discoveredNodes: seq[Node]) =
   for discNode in discoveredNodes:
@@ -110,6 +103,10 @@ proc setConnectedPeersMetrics(routingTableNodes: seq[Node],
 proc main() {.async.} = 
   let conf: NetworkMonitorConf = NetworkMonitorConf.load()
 
+  info "cli flags", conf=conf
+
+  # TODO: Run sanity checks on cli flags, i.e. bootstrap nodes
+
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)
 
@@ -138,25 +135,12 @@ proc main() {.async.} =
 
   # TODO: use other discovery mechanisms: i.e. dns
   
-  # TODO: Add flag
-  # waku prod bootstrap nodes
-  const bootstrapNodes = @[
-    # prod
-    "enr:-Nm4QOdTOKZJKTUUZ4O_W932CXIET-M9NamewDnL78P5u9DOGnZlK0JFZ4k0inkfe6iY-0JAaJVovZXc575VV3njeiABgmlkgnY0gmlwhAjS3ueKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuYWMtY24taG9uZ2tvbmctYy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhAo0C-VvfgHiXrxZi3umDiooXMGY9FvYj5_d1Q4EeS7eyg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP",
-    "enr:-M-4QLdAB-KyzT3QEsDoNa4LXT6RGH9BIylvTlDFLQhigWmxKEesulgc8AoKmVEUKj_4St6ThBKwyBc69tBfCe2hVTABgmlkgnY0gmlwhLymh5GKbXVsdGlhZGRyc7EALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi5wcm9kLnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDbl1X_zJIw3EAJGtmHMVn4Z2xhpSoUaP5ElsHKCv7hlWDdGNwgnZfg3VkcIIjKIV3YWt1Mg8",
-    "enr:-Nm4QNgc2L6L-4nk6jgllNDE1QDcn6kv2922rTRYs1wM3My_OmSsTimkMCIMh8fat6enFdYfuJ23KjWdF5whBz3zXgUBgmlkgnY0gmlwhCJ5ZGyKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuZ2MtdXMtY2VudHJhbDEtYS53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhA_30kHgQqfXZRioa4J_u5asgXTJ5iw_8w3lEICH4TFu_g3RjcIJ2X4N1ZHCCIyiFd2FrdTIP",
-    # test
-    "enr:-Nm4QC0_ClHzbsutYzgT3jJm7ZY1D4shylAdd6Ac-L4uwAUha1oHM0zwoEkTORVt94W5Cpa0IiyrTcXAYLgpRXpVNUsBgmlkgnY0gmlwhC_y0kmKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuYWMtY24taG9uZ2tvbmctYy53YWt1djIudGVzdC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhAhAm-P4q6mWONKcGnbLPU8WXZJ4Qs3AxIbrycvc7PVKsg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP",
-    "enr:-M-4QCtJKX2WDloRYDT4yjeMGKUCRRcMlsNiZP3cnPO0HZn6IdJ035RPCqsQ5NvTyjqHzKnTM6pc2LoKliV4CeV0WrgBgmlkgnY0gmlwhIbRi9KKbXVsdGlhZGRyc7EALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi50ZXN0LnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDnr03Tuo77930a7sYLikftxnuG3BbC3gCFhA4632ooDaDdGNwgnZfg3VkcIIjKIV3YWt1Mg8",
-    "enr:-Nm4QLHYoJ5WYQoVzyqPR-pwIeQvi3ONWs-EPwk3uUiBiDseN9Dd7fYbCvkMdeXcuZ-8U9IYdGm38VxSDf_Oq3zZ0cEBgmlkgnY0gmlwhGia74CKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuZ2MtdXMtY2VudHJhbDEtYS53YWt1djIudGVzdC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhA1giYsmWV9r2yJZYAiMGHJfjLlLeqAuTAokUGPN__pkxg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP",
-  ]
-  
   # mount discv5
   node.wakuDiscv5 = WakuDiscoveryV5.new(
       some(extIp), some(nodeTcpPort1), some(nodeUdpPort1),
       bindIp,
       nodeUdpPort1,
-      bootstrapNodes,
+      conf.bootstrapNodes,
       false,
       keys.PrivateKey(nodeKey1.skkey),
       flags,
@@ -191,12 +175,11 @@ proc main() {.async.} =
 
     info "discovered nodes: ", total=totalNodes, seen=seenNodes
 
-    # TODO: we dont run ipMajorityLoop
-    # TODO: we dont run revalidateLoop to not empty the routing table
-    # TODO: connect to nodes to see the protocol they actually support
+    # Notes:
+    # we dont run ipMajorityLoop
+    # we dont run revalidateLoop
 
-    # TODO: flag for how aggresive
-    await sleepAsync(1000*30)
+    await sleepAsync(conf.refreshInterval * 1000 * 60)
 
 when isMainModule:
   waitFor main()

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -113,7 +113,7 @@ proc main() {.async.} =
     for node in flatNodes: discovered_peers_list.set(int64(0),
                            labelValues = [node.record.toURI(), #enr
                                           $node.record.toTypedRecord().get().ip.get(), # TODO: Error handling. or what happens?
-                                          node.record.supportedCapabilites().join(",")]) 
+                                          node.record.getCapabilites().join(",")]) 
     # TODO: Some debug prints
     echo "total nodes: ", totalNodes
     echo "seen nodes: ", seenNodes

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -1,16 +1,16 @@
 import
-  confutils,
   std/[tables,strutils,times,sequtils,httpclient],
   chronicles,
   chronicles/topics_registry,
   chronos,
-  stew/shims/net,
-  presto/[route, server],
+  confutils,
+  eth/keys,
+  eth/p2p/discoveryv5/enr,
+  libp2p/crypto/crypto,
   metrics,
   metrics/chronos_httpserver,
-  libp2p/crypto/crypto,
-  eth/keys,
-  eth/p2p/discoveryv5/enr
+  presto/[route, server],
+  stew/shims/net
 
 import
   ../../waku/v2/node/discv5/waku_discv5,

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -12,22 +12,100 @@ import
   metrics/chronos_httpserver,
   libp2p/crypto/crypto,
   eth/keys,
-  eth/p2p/discoveryv5/enr,
+  eth/p2p/discoveryv5/enr
+
+import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/discv5/waku_discv5,
+  ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/wakunode2,
   ../../waku/v2/utils/wakuenr,
-  networkmonitor_metrics,
-  networkmonitor_config
+  ../../waku/v2/utils/peers,
+  ./networkmonitor_metrics,
+  ./networkmonitor_config
 
 logScope:
   topics = "networkmonitor"
-
+        
 # TODO: Move to utils
 proc flatten*[T](a: seq[seq[T]]): seq[T] =
   result = @[]
   for subseq in a:
     result &= subseq
+
+proc setDiscoveredPeersMetrics(discoveredNodes: seq[Node]) =
+  for discNode in discoveredNodes:
+    let typedRecord = discNode.record.toTypedRecord()
+    if not typedRecord.isOk():
+      warn "could not convert record to typed record", record=discNode.record
+      continue
+    if not typedRecord.get().ip.isSome():
+      warn "ip field is not set", record=typedRecord.get()
+      continue
+    let currentTime = $getTime()
+    discovered_peers_list.set(int64(0),
+                           labelValues = [discNode.record.toURI(),
+                                          $typedRecord.get().ip.get().join("."),
+                                          discNode.record.getCapabilities().join(","),
+                                          currentTime]) 
+
+proc setDiscoveredPeersCapabilities(routingTableNodes: seq[Node]) =
+  for capability in @[Relay, Store, Filter, Lightpush]:
+    let nOfNodesWithCapability = routingTableNodes.countIt(it.record.supportsCapability(capability))
+    info "capabilities as per ENR waku flag", capability=capability, amount=nOfNodesWithCapability
+    peer_type_as_per_enr.set(int64(nOfNodesWithCapability), labelValues = [$capability])
+
+proc setConnectedPeersMetrics(routingTableNodes: seq[Node],
+                              node: WakuNode,
+                              timeout: chronos.Duration) {.async.} =
+  var protocolCount: seq[seq[string]] = @[]
+  for discNode in routingTableNodes:
+    # ensure record is correct
+    let typedRecord = discNode.record.toTypedRecord()
+    if not typedRecord.isOk():
+      warn "could not convert record to typed record", record=discNode.record
+      continue
+    if not typedRecord.get().ip.isSome():
+      warn "ip field is not set", record=typedRecord.get()
+      continue
+          
+    let peer = toRemotePeerInfo(discNode.record)
+    if not peer.isOk():
+      warn "error converting record to remote peer info", record=discNode.record
+      continue
+    let timedOut = not await node.connectToNodes(@[peer.get()]).withTimeout(timeout)
+    if timedOut:
+      warn "could not connect to peer, timedout", timeout=timeout, peer=peer.get()
+      continue
+
+    # after connection, get supported protocols
+    let lp2pPeerStore = node.switch.peerStore
+    let nodeProtocols = lp2pPeerStore[ProtoBook][peer.get().peerId]
+
+    # store avaiable protocols in the network
+    protocolCount &= nodeProtocols
+
+    # update metrics with node info
+    let currentTime = $getTime()
+    connected_peers_list.set(int64(0),
+                           labelValues = [discNode.record.toURI(),
+                                          $typedRecord.get().ip.get().join("."),
+                                          nodeProtocols.join(","),
+                                          currentTime])
+    debug "connected to peer", enr=discNode.record.toURI(),
+                               ip=typedRecord.get().ip.get().join("."),
+                               protocols=nodeProtocols.join(",")
+   
+  # inform the total connections that we did in this round
+  let nOfOkConnections = protocolCount.len()
+  info "number of successful connections", amount=nOfOkConnections
+
+  # update count on each protocol
+  let allProtocols = protocolCount.flatten()
+  for protocol in allProtocols.deduplicate():
+    let countOfProtocols = allProtocols.count(protocol)
+    peer_type_as_per_protocol.set(int64(countOfProtocols), labelValues = [protocol])
+    info "supported protocols in the network", protocol=protocol, count=countOfProtocols
 
 proc main() {.async.} = 
   let conf: NetworkMonitorConf = NetworkMonitorConf.load()
@@ -52,15 +130,15 @@ proc main() {.async.} =
       bindIp,
       nodeTcpPort1)
     
+    # TODO: Propose refactor removing initWakuFlags
     flags = initWakuFlags(lightpush = false,
                           filter = false,
                           store = false,
                           relay = true)
 
-
-                        
   # TODO: use other discovery mechanisms: i.e. dns
   
+  # TODO: Add flag
   # waku prod bootstrap nodes
   const bootstrapNodes = @[
     # prod
@@ -82,7 +160,7 @@ proc main() {.async.} =
       false,
       keys.PrivateKey(nodeKey1.skkey),
       flags,
-      [], # Empty enr fields, for now
+      [],
       node.rng
     )
 
@@ -93,39 +171,25 @@ proc main() {.async.} =
     # discover new random nodes
     let discoveredNodes = await d.queryRandom()
 
-    for node in discoveredNodes:
-      let typedRecord = node.record.toTypedRecord()
-      if not typedRecord.isOk():
-        if not typedRecord.get().ip.isSome():
-          #TODO warn
-          continue
-      let currentTime = $getTime()
-      discovered_peers_list.set(int64(0),
-                           labelValues = [node.record.toURI(),
-                                          $typedRecord.get().ip.get().join("."),
-                                          node.record.getCapabilities().join(","),
-                                          currentTime]) 
-    
     # nodes are nested into bucket, flat it
     let flatNodes = d.routingTable.buckets.mapIt(it.nodes).flatten()
-
-    for capability in @[Relay, Store, Filter, Lightpush]:
-      let nOfNodesWithCapability = flatNodes.countIt(it.record.supportsCapability(capability))
-      # TODO: use debug instead
-      echo "nOfNodes: ", nOfNodesWithCapability, " supporting: ", $capability
-      peer_type_as_per_enr.set(int64(nOfNodesWithCapability), labelValues = [$capability])
     
-    # use flat nodes instead
+    # populate metrics related to discovered nodes
+    setDiscoveredPeersMetrics(discoveredNodes)
+
+    # populate metrics related to capabilities as advertised by the ENR (see waku field)
+    setDiscoveredPeersCapabilities(flatNodes)
+
+    # TODO: as this can't scale with thousands of peers,
+    # we would need to connect to just newly discovered nodes.
+    # tries to connect to all peers in the routing table
+    # populate metrics related to peers we could connect
+    await setConnectedPeersMetrics(flatNodes, node, conf.timeout)
+
     let totalNodes = flatNodes.len
     let seenNodes = flatNodes.countIt(it.seen)
 
-
-    # TODO: Some debug prints
-    echo "total nodes: ", totalNodes
-    echo "seen nodes: ", seenNodes
-
-    # TODO: connect to nodes to know the protocols they support
-    # store connection time
+    info "discovered nodes: ", total=totalNodes, seen=seenNodes
 
     # TODO: we dont run ipMajorityLoop
     # TODO: we dont run revalidateLoop to not empty the routing table

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -1,0 +1,83 @@
+import
+  confutils,
+  std/tables,
+  chronicles,
+  chronicles/topics_registry,
+  chronos,
+  stew/byteutils,
+  stew/shims/net,
+  libp2p/crypto/crypto,
+  eth/keys,
+  eth/p2p/discoveryv5/enr,
+  ../../waku/v2/protocol/waku_message,
+  ../../waku/v2/node/discv5/waku_discv5,
+  ../../waku/v2/node/wakunode2,
+  eth/keys
+
+type
+  NetworkMonitorConf* = object
+    logLevel* {.
+      desc: "Sets the log level",
+      defaultValue: LogLevel.DEBUG,
+      name: "log-level",
+      abbr: "l" .}: LogLevel
+
+proc main() {.async.} = 
+  let conf: NetworkMonitorConf = NetworkMonitorConf.load()
+  if conf.logLevel != LogLevel.NONE:
+    setLogLevel(conf.logLevel)
+
+  let
+    rng = keys.newRng()
+    bindIp = ValidIpAddress.init("0.0.0.0")
+    extIp = ValidIpAddress.init("127.0.0.1")
+    nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+    nodeTcpPort1 = Port(60000)
+    nodeUdpPort1 = Port(9000)
+    node1 = WakuNode.new(
+      nodeKey1,
+      bindIp,
+      nodeTcpPort1)
+    
+    flags = initWakuFlags(lightpush = false,
+                          filter = false,
+                          store = false,
+                          relay = true)
+  
+  # waku prod bootstrap nodes
+  const bootstrapNodes = @[
+    "enr:-JK4QPZWoojZJFRRxV87plIci5aaZMKaTs2YvvmCP7e0TGZPIxKWlkVExJc7xtdjUFw-SRj69FTul25o2uY2akaKpEcBgmlkgnY0gmlwhAjS3ueJc2VjcDI1NmsxoQKNAvlb34B4l68WYt7pg4qKFzBmPRb2I-f3dUOBHku3soN0Y3CCdl-DdWRwgiMohXdha3UyDw",
+    "enr:-JK4QIJuHZHTCaUOOwupvl7e3K1DyeDI6a609YJKdlovKj0pQa66P-2lMCw5oYUD-veYl0NNLW2CYHLYrC9CmZqDTLEBgmlkgnY0gmlwhLymh5GJc2VjcDI1NmsxoQNuXVf_MkjDcQAka2YcxWfhnbGGlKhRo_kSWwcoK_uGVYN0Y3CCdl-DdWRwgiMohXdha3UyDw",
+    "enr:-JK4QOgn2QQHSJCaLUZuxghlFL92VgL2eEd8LOyiYF0jyEkQUlH1KoOnPdcrO39qggSOsWECPWrO8GewdZmKhlvnHhQBgmlkgnY0gmlwhCJ5ZGyJc2VjcDI1NmsxoQP99JB4EKn12UYqGuCf7uWrIF0yeYsP_MN5RCAh-Exbv4N0Y3CCdl-DdWRwgiMohXdha3UyDw",
+  ]
+  
+  # mount discv5
+  node1.wakuDiscv5 = WakuDiscoveryV5.new(
+      some(extIp), some(nodeTcpPort1), some(nodeUdpPort1),
+      bindIp,
+      nodeUdpPort1,
+      bootstrapNodes,
+      false,
+      keys.PrivateKey(nodeKey1.skkey),
+      flags,
+      [], # Empty enr fields, for now
+      node1.rng
+    )
+  await node1.mountRelay()
+  await allFutures([node1.start()])
+  await allFutures([node1.startDiscv5()])
+
+  while true:
+    let discoveredPeers = await node1.wakuDiscv5.findRandomPeers()
+    echo node1.wakuDiscv5.protocol.nodesDiscovered
+    for bucket in node1.wakuDiscv5.protocol.routingTable.buckets:
+      for node in bucket.nodes:
+        echo "id", node.id
+        echo "pubkey", node.pubkey
+        echo "address", node.address
+        echo "seen", node.seen
+        echo "record", node.record
+    await sleepAsync(5000)
+
+when isMainModule:
+  waitFor main()

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -15,7 +15,7 @@ import
 import
   ../../waku/v2/node/discv5/waku_discv5,
   ../../waku/v2/node/peer_manager/peer_manager,
-  ../../waku/v2/node/wakunode2,
+  ../../waku/v2/node/waku_node,
   ../../waku/v2/utils/wakuenr,
   ../../waku/v2/utils/peers,
   ./networkmonitor_metrics,

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -5,6 +5,7 @@ import
   chronicles/topics_registry,
   chronos,
   stew/shims/net,
+  presto/[route, server],
   metrics,
   metrics/chronos_httpserver,
   libp2p/crypto/crypto,
@@ -24,65 +25,69 @@ import
 logScope:
   topics = "networkmonitor"
 
-proc setDiscoveredPeersMetrics(discoveredNodes: seq[Node], client: HttpClient) {.async.} =
-  for discNode in discoveredNodes:
-    let typedRecord = discNode.record.toTypedRecord()
-    if not typedRecord.isOk():
-      warn "could not convert record to typed record", record=discNode.record
-      continue
-    if not typedRecord.get().ip.isSome():
-      warn "ip field is not set", record=typedRecord.get()
-      continue
-    let currentTime = $getTime()
-
-    # get more info the peers from its ip address
-    let ip = $typedRecord.get().ip.get().join(".")
-    let location = await ipToLocation(ip, client)
-    if not location.isOk():
-      warn "could not get location", ip=ip
-      continue
-
-    # set metrics
-    discovered_peers_list.set(int64(0),
-                           labelValues = [discNode.record.toURI(),
-                                          ip,
-                                          discNode.record.getCapabilities().join(","),
-                                          currentTime,
-                                          location.get().country,
-                                          location.get().city])
-    debug "discovered peer", enr=discNode.record.toURI(),
-                             ip=ip,
-                             capabilities=discNode.record.getCapabilities().join(","),
-                             time=currentTime,
-                             country=location.get().country,
-                             city=location.get().city
-
-proc setDiscoveredPeersCapabilities(routingTableNodes: seq[Node]) =
+proc setDiscoveredPeersCapabilities(
+  routingTableNodes: seq[Node]) =
   for capability in @[Relay, Store, Filter, Lightpush]:
     let nOfNodesWithCapability = routingTableNodes.countIt(it.record.supportsCapability(capability))
     info "capabilities as per ENR waku flag", capability=capability, amount=nOfNodesWithCapability
     peer_type_as_per_enr.set(int64(nOfNodesWithCapability), labelValues = [$capability])
 
-proc setConnectedPeersMetrics(routingTableNodes: seq[Node],
+proc setConnectedPeersMetrics(discoveredNodes: seq[Node],
                               node: WakuNode,
                               timeout: chronos.Duration,
-                              client: HttpClient) {.async.} =
-  var allProtocols: seq[seq[string]] = @[]
-  var allAgentStrings: seq[string] = @[]
-  for discNode in routingTableNodes:
-    # ensure record is correct
+                              client: HttpClient,
+                              allPeers: CustomPeersTableRef) {.async.} =
+
+  let currentTime = $getTime()
+
+  # Protocols and agent string and its count
+  var allProtocols: Table[string, int]
+  var allAgentStrings: Table[string, int]
+
+  # iterate all newly discovered nodes
+  for discNode in discoveredNodes:
     let typedRecord = discNode.record.toTypedRecord()
     if not typedRecord.isOk():
       warn "could not convert record to typed record", record=discNode.record
       continue
+
+    let secp256k1 = typedRecord.get().secp256k1
+    if not secp256k1.isSome():
+      warn "could not get secp256k1 key", typedRecord=typedRecord.get()
+      continue
+
+    # create new entry if new peerId found
+    let peerId = secp256k1.get().toHex()
+    let customPeerInfo = CustomPeerInfo(peerId: peerId)
+    if not allPeers.hasKey(peerId):
+      allPeers[peerId] = customPeerInfo
+
+    allPeers[peerId].lastTimeDiscovered = currentTime
+    allPeers[peerId].enr = discNode.record.toURI()
+    allPeers[peerId].enrCapabilities = discNode.record.getCapabilities().mapIt($it)
+
     if not typedRecord.get().ip.isSome():
       warn "ip field is not set", record=typedRecord.get()
       continue
+
+    let ip = $typedRecord.get().ip.get().join(".")
+    allPeers[peerId].ip = ip
+
+    # get more info the peers from its ip address
+    let location = await ipToLocation(ip, client)
+    if not location.isOk():
+      warn "could not get location", ip=ip
+      continue
+
+    allPeers[peerId].country = location.get().country
+    allPeers[peerId].city = location.get().city
           
     let peer = toRemotePeerInfo(discNode.record)
     if not peer.isOk():
       warn "error converting record to remote peer info", record=discNode.record
       continue
+
+    # try to connect to the peer
     let timedOut = not await node.connectToNodes(@[peer.get()]).withTimeout(timeout)
     if timedOut:
       warn "could not connect to peer, timedout", timeout=timeout, peer=peer.get()
@@ -91,54 +96,39 @@ proc setConnectedPeersMetrics(routingTableNodes: seq[Node],
     # after connection, get supported protocols
     let lp2pPeerStore = node.switch.peerStore
     let nodeProtocols = lp2pPeerStore[ProtoBook][peer.get().peerId]
+    allPeers[peerId].supportedProtocols = nodeProtocols
+    allPeers[peerId].lastTimeConnected = currentTime
 
     # after connection, get user-agent
     let nodeUserAgent = lp2pPeerStore[AgentBook][peer.get().peerId]
+    allPeers[peerId].userAgent = nodeUserAgent
 
     # store avaiable protocols in the network
-    allProtocols &= nodeProtocols
+    for protocol in nodeProtocols:
+      if not allProtocols.hasKey(protocol):
+        allProtocols[protocol] = 0
+      allProtocols[protocol] += 1
 
     # store available user-agents in the network
-    allAgentStrings &= nodeUserAgent
+    if not allAgentStrings.hasKey(nodeUserAgent):
+      allAgentStrings[nodeUserAgent] = 0
+    allAgentStrings[nodeUserAgent] += 1
 
-    # get more info the peers from its ip address
-    let ip = $typedRecord.get().ip.get().join(".")
-    let location = await ipToLocation(ip, client)
-    if not location.isOk():
-      warn "could not get location", ip=ip
-      continue
-
-    # update metrics with node info
-    let currentTime = $getTime()
-    connected_peers_list.set(int64(0),
-                           labelValues = [discNode.record.toURI(),
-                                          ip,
-                                          nodeProtocols.join(","),
-                                          currentTime,
-                                          nodeUserAgent,
-                                          location.get().country,
-                                          location.get().city])
-    debug "connected to peer", enr=discNode.record.toURI(),
-                               ip=ip,
-                               protocols=nodeProtocols.join(","),
-                               userAgent=nodeUserAgent,
-                               country=location.get().country,
-                               city=location.get().city
+    debug "connected to peer", peer=allPeers[customPeerInfo.peerId]
    
   # inform the total connections that we did in this round
   let nOfOkConnections = allProtocols.len()
   info "number of successful connections", amount=nOfOkConnections
 
   # update count on each protocol
-  let allProtocolsFlat = allProtocols.flatten()
-  for protocol in allProtocolsFlat.deduplicate():
-    let countOfProtocols = allProtocolsFlat.count(protocol)
+  for protocol in allProtocols.keys():
+    let countOfProtocols = allProtocols[protocol]
     peer_type_as_per_protocol.set(int64(countOfProtocols), labelValues = [protocol])
     info "supported protocols in the network", protocol=protocol, count=countOfProtocols
 
   # update count on each user-agent
-  for userAgent in allAgentStrings.deduplicate():
-    let countOfUserAgent = allAgentStrings.count(userAgent)
+  for userAgent in allAgentStrings.keys():
+    let countOfUserAgent = allAgentStrings[userAgent]
     peer_user_agents.set(int64(countOfUserAgent), labelValues = [userAgent])
     info "user agents participating in the network", userAgent=userAgent, count=countOfUserAgent
 
@@ -195,15 +185,27 @@ proc main() {.async.} =
   let d = node.wakuDiscv5.protocol
   d.open()
 
+  # list of peers that we have discovered/connected
+  var allPeersRef = CustomPeersTableRef()
+
+  let serverAddress = initTAddress(conf.metricsRestAddress & ":" & $conf.metricsRestPort)
+  proc validate(pattern: string, value: string): int =
+    if pattern.startsWith("{") and pattern.endsWith("}"): 0
+    else: 1
+  var router = RestRouter.init(validate)
+  router.installHandler(allPeersRef)
+
+  # rest server for custom metrics
+  var sres = RestServerRef.new(router, serverAddress)
+  let restServer = sres.get()
+  restServer.start()
+
   while true:
     # discover new random nodes
     let discoveredNodes = await d.queryRandom()
 
     # nodes are nested into bucket, flat it
     let flatNodes = d.routingTable.buckets.mapIt(it.nodes).flatten()
-    
-    # populate metrics related to discovered nodes
-    await setDiscoveredPeersMetrics(discoveredNodes, client)
 
     # populate metrics related to capabilities as advertised by the ENR (see waku field)
     setDiscoveredPeersCapabilities(flatNodes)
@@ -211,7 +213,7 @@ proc main() {.async.} =
     # tries to connect to all newly discovered nodes
     # and populates metrics related to peers we could connect
     # note random discovered nodes can be already known
-    await setConnectedPeersMetrics(discoveredNodes, node, conf.timeout, client)
+    await setConnectedPeersMetrics(discoveredNodes, node, conf.timeout, client, allPeersRef)
 
     let totalNodes = flatNodes.len
     let seenNodes = flatNodes.countIt(it.seen)

--- a/tools/networkmonitor/networkmonitor_config.nim
+++ b/tools/networkmonitor/networkmonitor_config.nim
@@ -1,0 +1,38 @@
+import
+  confutils,
+  stew/shims/net,
+  chronicles,
+  chronicles/topics_registry
+
+type
+  NetworkMonitorConf* = object
+    logLevel* {.
+      desc: "Sets the log level",
+      defaultValue: LogLevel.DEBUG,
+      name: "log-level",
+      abbr: "l" .}: LogLevel
+
+    ## Metrics config
+    metricsServer* {.
+      desc: "Enable the metrics server: true|false"
+      defaultValue: true
+      name: "metrics-server" }: bool
+
+    metricsServerAddress* {.
+      desc: "Listening address of the metrics server."
+      defaultValue: ValidIpAddress.init("127.0.0.1")
+      name: "metrics-server-address" }: ValidIpAddress
+
+    metricsServerPort* {.
+      desc: "Listening HTTP port of the metrics server."
+      defaultValue: 8008
+      name: "metrics-server-port" }: uint16
+
+proc parseCmdArg*(T: type ValidIpAddress, p: TaintedString): T =
+  try:
+    result = ValidIpAddress.init(p)
+  except CatchableError as e:
+    raise newException(ConfigurationError, "Invalid IP address")
+
+proc completeCmdArg*(T: type ValidIpAddress, val: TaintedString): seq[string] =
+  return @[]

--- a/tools/networkmonitor/networkmonitor_config.nim
+++ b/tools/networkmonitor/networkmonitor_config.nim
@@ -4,6 +4,7 @@ import
   chronicles/topics_registry,
   chronos,
   confutils,
+  stew/results,
   stew/shims/net
 
 type
@@ -72,7 +73,14 @@ proc parseCmdArg*(T: type chronos.Duration, p: string): T =
   try:
     result = chronos.seconds(parseInt(p))
   except CatchableError as e:
-    raise newException(ConfigurationError, "Invalid timeout value")
+    raise newException(ConfigurationError, "Invalid duration value")
 
 proc completeCmdArg*(T: type chronos.Duration, val: string): seq[string] =
   return @[]
+
+proc loadConfig*(T: type NetworkMonitorConf): Result[T, string] =
+  try:
+    let conf = NetworkMonitorConf.load()
+    ok(conf)
+  except CatchableError:
+    err(getCurrentExceptionMsg())

--- a/tools/networkmonitor/networkmonitor_config.nim
+++ b/tools/networkmonitor/networkmonitor_config.nim
@@ -1,11 +1,10 @@
-# TODO fix imports
 import
-  confutils,
-  strutils,
-  chronos,
-  stew/shims/net,
+  std/strutils,
   chronicles,
-  chronicles/topics_registry
+  chronicles/topics_registry,
+  chronos,
+  confutils,
+  stew/shims/net
 
 type
   NetworkMonitorConf* = object

--- a/tools/networkmonitor/networkmonitor_config.nim
+++ b/tools/networkmonitor/networkmonitor_config.nim
@@ -1,5 +1,8 @@
+# TODO fix imports
 import
   confutils,
+  strutils,
+  chronos,
   stew/shims/net,
   chronicles,
   chronicles/topics_registry
@@ -11,6 +14,12 @@ type
       defaultValue: LogLevel.DEBUG,
       name: "log-level",
       abbr: "l" .}: LogLevel
+
+    timeout* {.
+      desc: "Timeout to consider that the connection failed",
+      defaultValue: chronos.seconds(10),
+      name: "timeout",
+      abbr: "t" }: chronos.Duration
 
     ## Metrics config
     metricsServer* {.
@@ -35,4 +44,13 @@ proc parseCmdArg*(T: type ValidIpAddress, p: TaintedString): T =
     raise newException(ConfigurationError, "Invalid IP address")
 
 proc completeCmdArg*(T: type ValidIpAddress, val: TaintedString): seq[string] =
+  return @[]
+
+proc parseCmdArg*(T: type chronos.Duration, p: TaintedString): T =
+  try:
+      result = chronos.seconds(parseInt(p))
+  except CatchableError as e:
+    raise newException(ConfigurationError, "Invalid timeout value")
+
+proc completeCmdArg*(T: type chronos.Duration, val: TaintedString): seq[string] =
   return @[]

--- a/tools/networkmonitor/networkmonitor_config.nim
+++ b/tools/networkmonitor/networkmonitor_config.nim
@@ -1,3 +1,8 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+  
 import
   std/strutils,
   chronicles,

--- a/tools/networkmonitor/networkmonitor_config.nim
+++ b/tools/networkmonitor/networkmonitor_config.nim
@@ -33,7 +33,7 @@ type
       name: "refresh-interval",
       abbr: "r" }: int
 
-    ## Metrics config
+    ## Prometheus metrics config
     metricsServer* {.
       desc: "Enable the metrics server: true|false"
       defaultValue: true
@@ -48,6 +48,17 @@ type
       desc: "Listening HTTP port of the metrics server."
       defaultValue: 8008
       name: "metrics-server-port" }: uint16
+
+    ## Custom metrics rest server
+    metricsRestAddress* {.
+      desc: "Listening address of the metrics rest server.",
+      defaultValue: "127.0.0.1",
+      name: "metrics-rest-address" }: string
+    metricsRestPort* {.
+      desc: "Listening HTTP port of the metrics rest server.",
+      defaultValue: 8009,
+      name: "metrics-rest-port" }: uint16
+    
 
 proc parseCmdArg*(T: type ValidIpAddress, p: TaintedString): T =
   try:

--- a/tools/networkmonitor/networkmonitor_config.nim
+++ b/tools/networkmonitor/networkmonitor_config.nim
@@ -21,6 +21,18 @@ type
       name: "timeout",
       abbr: "t" }: chronos.Duration
 
+    bootstrapNodes* {.
+      desc: "Bootstrap ENR node. Argument may be repeated.",
+      defaultValue: @[""],
+      name: "bootstrap-node",
+      abbr: "b" }: seq[string]
+
+    refreshInterval* {.
+      desc: "How often new peers are discovered and connected to (in minutes)",
+      defaultValue: 10,
+      name: "refresh-interval",
+      abbr: "r" }: int
+
     ## Metrics config
     metricsServer* {.
       desc: "Enable the metrics server: true|false"

--- a/tools/networkmonitor/networkmonitor_config.nim
+++ b/tools/networkmonitor/networkmonitor_config.nim
@@ -1,8 +1,3 @@
-when (NimMajor, NimMinor) < (1, 4):
-  {.push raises: [Defect].}
-else:
-  {.push raises: [].}
-  
 import
   std/strutils,
   chronicles,
@@ -64,20 +59,20 @@ type
       name: "metrics-rest-port" }: uint16
     
 
-proc parseCmdArg*(T: type ValidIpAddress, p: TaintedString): T =
+proc parseCmdArg*(T: type ValidIpAddress, p: string): T =
   try:
     result = ValidIpAddress.init(p)
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid IP address")
 
-proc completeCmdArg*(T: type ValidIpAddress, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type ValidIpAddress, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type chronos.Duration, p: TaintedString): T =
+proc parseCmdArg*(T: type chronos.Duration, p: string): T =
   try:
-      result = chronos.seconds(parseInt(p))
+    result = chronos.seconds(parseInt(p))
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid timeout value")
 
-proc completeCmdArg*(T: type chronos.Duration, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type chronos.Duration, val: string): seq[string] =
   return @[]

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -1,0 +1,29 @@
+import
+  confutils,
+  std/tables,
+  chronicles,
+  chronicles/topics_registry,
+  metrics,
+  metrics/chronos_httpserver,
+  stew/shims/net
+
+logScope:
+  topics = "networkmonitor_metrics"
+
+# TODO: remove dummy test
+declarePublicHistogram networkmonitor_example, "my test"
+
+# TODO: add metrics
+# discovered nodes with Relay, Store, Filter, Lightpush capabilities
+# full enrs
+# ips (useful for location)
+
+proc startMetricsServer*(serverIp: ValidIpAddress, serverPort: Port) =
+    info "Starting metrics HTTP server", serverIp, serverPort
+    
+    try:
+      startMetricsHttpServer($serverIp, serverPort)
+    except Exception as e:
+      raiseAssert("Exception while starting metrics HTTP server: " & e.msg)
+
+    info "Metrics HTTP server started", serverIp, serverPort

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -28,14 +28,16 @@ declarePublicGauge peer_type_as_per_protocol,
     "Number of peers supporting each capability according to the protocol (requiere successful connection) ",
     labels = ["capability"]
 
+# hackish way for exponse strings, not performant at all
 declarePublicGauge discovered_peers_list,
     "Discovered peers in the waku network and its information",
     labels = ["enr",
               "ip",
-              "capabilities",]
+              "capabilities",
+              "discovered_timestamp",
               #"citiy",
               #"country",
-              #"last_seen"]
+              ]
 
 proc startMetricsServer*(serverIp: ValidIpAddress, serverPort: Port) =
     info "Starting metrics HTTP server", serverIp, serverPort

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -1,5 +1,4 @@
 import
-  confutils,
   std/tables,
   chronicles,
   chronicles/topics_registry,

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -28,6 +28,10 @@ declarePublicGauge peer_type_as_per_protocol,
     "Number of peers supporting each protocol, after a successful connection) ",
     labels = ["protocols"]
 
+declarePublicGauge peer_user_agents,
+    "Number of peers with each user agent",
+    labels = ["user_agent"]
+
 # hackish way for exponse strings, not performant at all
 declarePublicGauge discovered_peers_list,
     "Discovered peers in the waku network and its information",
@@ -46,6 +50,7 @@ declarePublicGauge connected_peers_list,
               "ip",
               "capabilities",
               "connected_timestamp",
+              "user_agent",
               #"citiy",
               #"country",
               ]

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -1,11 +1,12 @@
 import
   std/[json,tables,sequtils],
-  presto/[route, server],
-  chronos,
   chronicles,
   chronicles/topics_registry,
+  chronos,
   metrics,
   metrics/chronos_httpserver,
+  presto/route,
+  presto/server,
   stew/shims/net
 
 logScope:

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -1,3 +1,8 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+  
 import
   std/[json,tables,sequtils],
   chronicles,

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -38,8 +38,8 @@ declarePublicGauge discovered_peers_list,
               "ip",
               "capabilities",
               "discovered_timestamp",
-              #"citiy",
-              #"country",
+              "country",
+              "citiy",
               ]
 
 # hackish way for exponse strings, not performant at all
@@ -50,8 +50,8 @@ declarePublicGauge connected_peers_list,
               "capabilities",
               "connected_timestamp",
               "user_agent",
-              #"citiy",
-              #"country",
+              "country",
+              "citiy",
               ]
 
 proc startMetricsServer*(serverIp: ValidIpAddress, serverPort: Port) =

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -10,13 +10,32 @@ import
 logScope:
   topics = "networkmonitor_metrics"
 
-# TODO: remove dummy test
-declarePublicHistogram networkmonitor_example, "my test"
+# Metric ideas:
+# histogram with latency
+# number of peers hosted behind each ip
 
-# TODO: add metrics
-# discovered nodes with Relay, Store, Filter, Lightpush capabilities
-# full enrs
-# ips (useful for location)
+# On top of our custom metrics, the following are reused from nim-eth
+#routing_table_nodes{state=""}
+#routing_table_nodes{state="seen"}
+#discovery_message_requests_outgoing_total{response=""}
+#discovery_message_requests_outgoing_total{response="no_response"}
+
+declarePublicGauge peer_type_as_per_enr,
+    "Number of peers supporting each capability according the the ENR",
+    labels = ["capability"]
+
+declarePublicGauge peer_type_as_per_protocol,
+    "Number of peers supporting each capability according to the protocol (requiere successful connection) ",
+    labels = ["capability"]
+
+declarePublicGauge discovered_peers_list,
+    "Discovered peers in the waku network and its information",
+    labels = ["enr",
+              "ip",
+              "capabilities",]
+              #"citiy",
+              #"country",
+              #"last_seen"]
 
 proc startMetricsServer*(serverIp: ValidIpAddress, serverPort: Port) =
     info "Starting metrics HTTP server", serverIp, serverPort

--- a/tools/networkmonitor/networkmonitor_metrics.nim
+++ b/tools/networkmonitor/networkmonitor_metrics.nim
@@ -25,8 +25,8 @@ declarePublicGauge peer_type_as_per_enr,
     labels = ["capability"]
 
 declarePublicGauge peer_type_as_per_protocol,
-    "Number of peers supporting each capability according to the protocol (requiere successful connection) ",
-    labels = ["capability"]
+    "Number of peers supporting each protocol, after a successful connection) ",
+    labels = ["protocols"]
 
 # hackish way for exponse strings, not performant at all
 declarePublicGauge discovered_peers_list,
@@ -35,6 +35,17 @@ declarePublicGauge discovered_peers_list,
               "ip",
               "capabilities",
               "discovered_timestamp",
+              #"citiy",
+              #"country",
+              ]
+
+# hackish way for exponse strings, not performant at all
+declarePublicGauge connected_peers_list,
+    "Peers that we successfully connected to and its information",
+    labels = ["enr",
+              "ip",
+              "capabilities",
+              "connected_timestamp",
               #"citiy",
               #"country",
               ]

--- a/tools/networkmonitor/networkmonitor_utils.nim
+++ b/tools/networkmonitor/networkmonitor_utils.nim
@@ -1,3 +1,8 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+  
 import
   std/[json,httpclient],
   chronicles,
@@ -14,9 +19,10 @@ type
     isp*: string
 
 proc flatten*[T](a: seq[seq[T]]): seq[T] =
-  result = @[]
+  var aFlat = newSeq[T](0)
   for subseq in a:
-    result &= subseq
+    aFlat &= subseq
+  return aFlat
 
 # using an external api retrieves some data associated with the ip
 # TODO: use a cache

--- a/tools/networkmonitor/networkmonitor_utils.nim
+++ b/tools/networkmonitor/networkmonitor_utils.nim
@@ -1,0 +1,4 @@
+proc flatten*[T](a: seq[seq[T]]): seq[T] =
+  result = @[]
+  for subseq in a:
+    result &= subseq

--- a/tools/networkmonitor/networkmonitor_utils.nim
+++ b/tools/networkmonitor/networkmonitor_utils.nim
@@ -26,6 +26,7 @@ proc flatten*[T](a: seq[seq[T]]): seq[T] =
 
 # using an external api retrieves some data associated with the ip
 # TODO: use a cache
+# TODO: use nim-presto's HTTP asynchronous client
 proc ipToLocation*(ip: string,
                    client: Httpclient):
                    Future[Result[NodeLocation, string]] {.async.} =
@@ -48,5 +49,5 @@ proc ipToLocation*(ip: string,
       isp:     jsonContent["isp"].getStr()
     ))
   except:
-    error "failed to get location for IP", ip=ip, excep=getCurrentException().msg
-    return err("could not get location for IP: " & ip)
+    error "failed to get the location for IP", ip=ip, error=getCurrentExceptionMsg()
+    return err("failed to get the location for IP '" & ip & "':" & getCurrentExceptionMsg())

--- a/tools/networkmonitor/networkmonitor_utils.nim
+++ b/tools/networkmonitor/networkmonitor_utils.nim
@@ -1,4 +1,47 @@
+import
+  std/[json,httpclient]
+import
+  chronicles,
+  chronicles/topics_registry,
+  chronos,
+  stew/results
+
+type
+  NodeLocation = object
+    country*: string
+    city*: string
+    lat*: string
+    long*: string
+    isp*: string
+
 proc flatten*[T](a: seq[seq[T]]): seq[T] =
   result = @[]
   for subseq in a:
     result &= subseq
+
+# using an external api retrieves some data associated with the ip
+# TODO: use a cache
+proc ipToLocation*(ip: string,
+                   client: Httpclient):
+                   Future[Result[NodeLocation, string]] {.async.} =
+  # naive mechanism to avoid hitting the rate limit
+  # IP-API endpoints are now limited to 45 HTTP requests per minute
+  await sleepAsync(1400)
+  try:
+    let content = client.getContent("http://ip-api.com/json/" & ip)
+    let jsonContent = parseJson(content)
+
+    if $jsonContent["status"].getStr() != "success":
+      error "query failed", result=jsonContent
+      return err("query failed: " & $jsonContent)
+
+    return ok(NodeLocation(
+      country: jsonContent["country"].getStr(),
+      city:    jsonContent["city"].getStr(),
+      lat:     jsonContent["lat"].getStr(),
+      long:    jsonContent["lon"].getStr(),
+      isp:     jsonContent["isp"].getStr()
+    ))
+  except:
+    error "failed to get location for IP", ip=ip, excep=getCurrentException().msg
+    return err("could not get location for IP: " & ip)

--- a/tools/networkmonitor/networkmonitor_utils.nim
+++ b/tools/networkmonitor/networkmonitor_utils.nim
@@ -1,6 +1,5 @@
 import
-  std/[json,httpclient]
-import
+  std/[json,httpclient],
   chronicles,
   chronicles/topics_registry,
   chronos,

--- a/tools/networkmonitor/nim.cfg
+++ b/tools/networkmonitor/nim.cfg
@@ -1,0 +1,3 @@
+-d:chronicles_line_numbers
+-d:chronicles_runtime_filtering:on
+-d:discv5_protocol_id:d5waku

--- a/waku.nimble
+++ b/waku.nimble
@@ -107,4 +107,8 @@ task chat2bridge, "Build chat2bridge":
 ### Waku Tooling
 task wakucanary, "Build waku-canary tool":
   let name = "wakucanary"
-  buildBinary name, "tools/wakucanary/", "-d:chronicles_log_level=TRACE"
+  buildBinary name, "tools/wakucanary/", "-d:chronicles_log_level=TRACE -d:chronicles_runtime_filtering:on"
+
+task networkmonitor, "Build network monitor tool":
+  let name = "networkmonitor"
+  buildBinary name, "tools/networkmonitor/", "-d:chronicles_log_level=TRACE -d:chronicles_runtime_filtering:on"

--- a/waku.nimble
+++ b/waku.nimble
@@ -107,8 +107,8 @@ task chat2bridge, "Build chat2bridge":
 ### Waku Tooling
 task wakucanary, "Build waku-canary tool":
   let name = "wakucanary"
-  buildBinary name, "tools/wakucanary/", "-d:chronicles_log_level=TRACE -d:chronicles_runtime_filtering:on"
+  buildBinary name, "tools/wakucanary/", "-d:chronicles_log_level=TRACE"
 
 task networkmonitor, "Build network monitor tool":
   let name = "networkmonitor"
-  buildBinary name, "tools/networkmonitor/", "-d:chronicles_log_level=TRACE -d:chronicles_runtime_filtering:on"
+  buildBinary name, "tools/networkmonitor/", "-d:chronicles_log_level=TRACE"

--- a/waku/v2/utils/wakuenr.nim
+++ b/waku/v2/utils/wakuenr.nim
@@ -11,7 +11,8 @@ import
   libp2p/[multiaddress, multicodec],
   libp2p/crypto/crypto,
   stew/[endians2, results],
-  stew/shims/net
+  stew/shims/net,
+  std/bitops
 
 export enr, crypto, multiaddress, net
 
@@ -23,7 +24,15 @@ type
   ## 8-bit flag field to indicate Waku capabilities.
   ## Only the 4 LSBs are currently defined according
   ## to RFC31 (https://rfc.vac.dev/spec/31/).
-  WakuEnrBitfield* = uint8 
+  WakuEnrBitfield* = uint8
+
+  ## See: https://rfc.vac.dev/spec/31/#waku2-enr-key
+  ## each enum numbers maps to a bit (where 0 is the LSB)
+  Capabilities* = enum
+    Relay = 0,
+    Store = 1,
+    Filter = 2,
+    Lightpush = 3,
 
 func toFieldPair(multiaddrs: seq[MultiAddress]): FieldPair =
   ## Converts a seq of multiaddrs to a `multiaddrs` ENR
@@ -151,3 +160,16 @@ func initEnr*(privateKey: crypto.PrivateKey,
                           wakuEnrFields).expect("Record within size limits")
   
   return enr
+
+proc supportsCapability*(r: Record, capability: Capabilities): bool = 
+  let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[byte])[]
+  # TODO: not nice but seq[uint8] does not work
+  #let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[uint8])[]
+
+  # TODO: Check this, cast[uint8](enrCapabilities) does not work
+  #echo "enrCapabilities: ", enrCapabilities
+  #echo "cast[uint8](capability)", cast[uint8](capability), "cast[uint8](enrCapabilities)", cast[uint8](enrCapabilities)
+  #return testBit(cast[uint8](enrCapabilities), cast[uint8](capability))
+
+  # TODO:
+  return true

--- a/waku/v2/utils/wakuenr.nim
+++ b/waku/v2/utils/wakuenr.nim
@@ -99,6 +99,14 @@ func initWakuFlags*(lightpush, filter, store, relay: bool): WakuEnrBitfield =
   if store: v.setBit(1)
   if relay: v.setBit(0)
 
+  # TODO: With the changes in this PR, this can be refactored? Using the enum?
+  # Perhaps refactor to:
+    # WaKuEnr.initEnr(..., capabilities=[Store, Lightpush])
+    # WaKuEnr.initEnr(..., capabilities=[Store, Lightpush, Relay, Filter])
+
+  # Safer also since we dont inject WakuEnrBitfield, and we let this package
+  # handle the bits according to the capabilities
+
   return v.WakuEnrBitfield
 
 func toMultiAddresses*(multiaddrsField: seq[byte]): seq[MultiAddress] =
@@ -163,13 +171,4 @@ func initEnr*(privateKey: crypto.PrivateKey,
 
 proc supportsCapability*(r: Record, capability: Capabilities): bool = 
   let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[byte])[]
-  # TODO: not nice but seq[uint8] does not work
-  #let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[uint8])[]
-
-  # TODO: Check this, cast[uint8](enrCapabilities) does not work
-  #echo "enrCapabilities: ", enrCapabilities
-  #echo "cast[uint8](capability)", cast[uint8](capability), "cast[uint8](enrCapabilities)", cast[uint8](enrCapabilities)
-  #return testBit(cast[uint8](enrCapabilities), cast[uint8](capability))
-
-  # TODO:
-  return true
+  return testBit(enrCapabilities[0], capability.ord)

--- a/waku/v2/utils/wakuenr.nim
+++ b/waku/v2/utils/wakuenr.nim
@@ -169,6 +169,14 @@ func initEnr*(privateKey: crypto.PrivateKey,
   
   return enr
 
+# TODO: use isWakuNode?
 proc supportsCapability*(r: Record, capability: Capabilities): bool = 
+  # TODO: error handling, this is not safe
   let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[byte])[]
   return testBit(enrCapabilities[0], capability.ord)
+
+# TODO: Add tests for this
+proc supportedCapabilites*(r: Record): seq[Capabilities] =
+  # TODO: Error handling
+  let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[byte])[]
+  return toSeq(Capabilities.low..Capabilities.high).filterIt(r.supportsCapability(it))

--- a/waku/v2/utils/wakuenr.nim
+++ b/waku/v2/utils/wakuenr.nim
@@ -169,14 +169,11 @@ func initEnr*(privateKey: crypto.PrivateKey,
   
   return enr
 
-# TODO: use isWakuNode?
 proc supportsCapability*(r: Record, capability: Capabilities): bool = 
-  # TODO: error handling, this is not safe
-  let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[byte])[]
-  return testBit(enrCapabilities[0], capability.ord)
+  let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[byte])
+  if enrCapabilities.isOk():
+    return testBit(enrCapabilities.get()[0], capability.ord)
+  return false
 
-# TODO: Add tests for this
-proc supportedCapabilites*(r: Record): seq[Capabilities] =
-  # TODO: Error handling
-  let enrCapabilities = r.get(WAKU_ENR_FIELD, seq[byte])[]
+proc getCapabilities*(r: Record): seq[Capabilities] =
   return toSeq(Capabilities.low..Capabilities.high).filterIt(r.supportsCapability(it))


### PR DESCRIPTION
Related to #1010

Description:
* Adds a tool that constantly tries to discover new peers in the network.
* It also tries to connect to them.
* See `README.md` for instructions and available metrics.
* Goal is to run a long lived instante of this tool, with a grafana dashboard we can monitor.
* Some metrics are exposed to prometheus to be fetched. Labels are constrained according do @jakubgs feedback.
* Other metrics, related to individual peers information are exposed directly via a rest api, ready to be accessed by i.e. Grafana. Note that these metrics are not exposed to prometheus.

Limitations:
* Naive implementation, with all data stored in memory. If the network scales to thousands of node the performance might be an issue.
* Routing table is not emptied.

Usage:

```console
$ make networkmonitor
$ ./build/networkmonitor --log-level=INFO --b="enr:-Nm4QOdTOKZJKTUUZ4O_W932CXIET-M9NamewDnL78P5u9DOGnZlK0JFZ4k0inkfe6iY-0JAaJVovZXc575VV3njeiABgmlkgnY0gmlwhAjS3ueKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuYWMtY24taG9uZ2tvbmctYy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhAo0C-VvfgHiXrxZi3umDiooXMGY9FvYj5_d1Q4EeS7eyg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP"
```

And:
* See prometheus metrics `http://localhost:8008/metrics`
* See custom metrics `http://localhost:8009/allpeersinfo`