### PR TITLE
feat(store): simplify wakunode2 configuration options

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,4 +15,8 @@ pkgs.mkShell {
     libiconv
     darwin.apple_sdk.frameworks.Security
   ];
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+    pkgs.pcre
+  ];
 }


### PR DESCRIPTION
The first part of the work simplifies the store configuration. Added new configuration options and deprecated the old ones.

Check for more details: #1103

The refactoring of the `wakunode2` setup sequence to support the new simplified store and persistence configuration options will be performed as part of the subsequent PR.