### PR TITLE
feat(lightpush): add waku lightpush protocol client

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -4,7 +4,6 @@ import
   # ./v2/test_waku,
   ./v2/test_wakunode,
   ./v2/test_wakunode_relay,
-  ./v2/test_wakunode_lightpush,
   # Waku Store
   ./v2/test_message_store_queue_index,
   ./v2/test_message_store_queue_pagination,
@@ -17,6 +16,9 @@ import
   # TODO: Re-enable store resume test cases (#1282)
   # ./v2/test_waku_store_resume,
   ./v2/test_wakunode_store,
+  # Waku LightPush
+  ./v2/test_waku_lightpush,
+  ./v2/test_wakunode_lightpush,
   # Waku Filter
   ./v2/test_waku_filter,
   ./v2/test_wakunode_filter,

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -59,7 +59,7 @@ procSuite "WakuNode - Lightpush":
     ## When
     let lightpushRes = await lightNode.lightpush(DefaultPubsubTopic, message)
 
-    require (await completionFutRelay.withTimeout(5.seconds)) == true
+    require await completionFutRelay.withTimeout(5.seconds)
     
     ## Then
     check lightpushRes.isOk()

--- a/tests/v2/testlib/common.nim
+++ b/tests/v2/testlib/common.nim
@@ -1,5 +1,6 @@
 import
-  std/times
+  std/times,
+  stew/byteutils
 import
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/utils/time

--- a/waku/v2/node/waku_metrics.nim
+++ b/waku/v2/node/waku_metrics.nim
@@ -9,8 +9,8 @@ import
   metrics/chronos_httpserver
 import
   ../protocol/waku_filter,
-  ../protocol/waku_store/protocol_metrics,
-  ../protocol/waku_lightpush,
+  ../protocol/waku_store/protocol_metrics as store_metrics,
+  ../protocol/waku_lightpush/protocol_metrics as lightpush_metrics,
   ../protocol/waku_swap/waku_swap,
   ../protocol/waku_peer_exchange,
   ../utils/collector,

--- a/waku/v2/protocol/waku_lightpush/client.nim
+++ b/waku/v2/protocol/waku_lightpush/client.nim
@@ -1,0 +1,79 @@
+{.push raises: [Defect].}
+
+import
+  std/options,
+  stew/results,
+  chronicles,
+  chronos,
+  metrics,
+  bearssl/rand
+import
+  ../../node/peer_manager/peer_manager,
+  ../../utils/requests,
+  ./protocol,
+  ./protocol_metrics,
+  ./rpc,
+  ./rpc_codec
+
+
+logScope:
+  topics = "wakulightpush.client"
+
+
+type WakuLightPushClient* = ref object
+    peerManager*: PeerManager
+    rng*: ref rand.HmacDrbgContext
+
+
+proc new*(T: type WakuLightPushClient, 
+          peerManager: PeerManager, 
+          rng: ref rand.HmacDrbgContext): T =
+  WakuLightPushClient(peerManager: peerManager, rng: rng)
+
+
+proc request*(wl: WakuLightPushClient, req: PushRequest, peer: RemotePeerInfo): Future[WakuLightPushResult[void]] {.async, gcsafe.} = 
+  let connOpt = await wl.peerManager.dialPeer(peer, WakuLightPushCodec)
+  if connOpt.isNone():
+    waku_lightpush_errors.inc(labelValues = [dialFailure])
+    return err(dialFailure)
+  let connection = connOpt.get()
+
+  let rpc = PushRPC(requestId: generateRequestId(wl.rng), request: req)
+  await connection.writeLP(rpc.encode().buffer)
+
+  var message = await connection.readLp(MaxRpcSize.int)
+  let decodeRespRes = PushRPC.init(message)
+  if decodeRespRes.isErr():
+    error "failed to decode response"
+    waku_lightpush_errors.inc(labelValues = [decodeRpcFailure])
+    return err(decodeRpcFailure)
+
+  let pushResponseRes = decodeRespRes.get()
+  if pushResponseRes.response == PushResponse():
+    waku_lightpush_errors.inc(labelValues = [emptyResponseBodyFailure])
+    return err(emptyResponseBodyFailure)
+
+  let response = pushResponseRes.response
+  if not response.isSuccess:
+    if response.info != "":
+      return err(response.info)
+    else:
+      return err("unknown failure")
+
+  return ok()
+
+
+### Set lightpush peer and send push requests
+
+proc setPeer*(wl: WakuLightPushClient, peer: RemotePeerInfo) =
+  wl.peerManager.addPeer(peer, WakuLightPushCodec)
+  waku_lightpush_peers.inc()
+
+proc request*(wl: WakuLightPushClient, req: PushRequest): Future[WakuLightPushResult[void]] {.async, gcsafe.} =
+  let peerOpt = wl.peerManager.selectPeer(WakuLightPushCodec)
+  if peerOpt.isNone():
+    error "no suitable remote peers"
+    waku_lightpush_errors.inc(labelValues = [peerNotFoundFailure])
+    return err(peerNotFoundFailure)
+
+  return await wl.request(req, peerOpt.get())

--- a/waku/v2/protocol/waku_lightpush/protocol_metrics.nim
+++ b/waku/v2/protocol/waku_lightpush/protocol_metrics.nim
@@ -1,0 +1,18 @@
+{.push raises: [Defect].}
+
+import metrics
+
+
+declarePublicGauge waku_lightpush_peers, "number of lightpush peers"
+declarePublicGauge waku_lightpush_errors, "number of lightpush protocol errors", ["type"]
+declarePublicGauge waku_lightpush_messages, "number of lightpush messages received", ["type"]
+
+
+# Error types (metric label values)
+const
+  dialFailure* = "dial_failure"
+  decodeRpcFailure* = "decode_rpc_failure"
+  peerNotFoundFailure* = "peer_not_found_failure"
+  emptyRequestBodyFailure* = "empty_request_body_failure"
+  emptyResponseBodyFailure* = "empty_response_body_failure"
+  messagePushFailure* = "message_push_failure"

--- a/waku/v2/protocol/waku_lightpush/rpc_codec.nim
+++ b/waku/v2/protocol/waku_lightpush/rpc_codec.nim
@@ -9,6 +9,9 @@ import
   ./rpc
 
 
+const MaxRpcSize* = MaxWakuMessageSize + 64 * 1024 # We add a 64kB safety buffer for protocol overhead
+
+
 proc encode*(rpc: PushRequest): ProtoBuffer =
   var output = initProtoBuffer()
   output.write3(1, rpc.pubSubTopic)

--- a/waku/v2/protocol/waku_store/client.nim
+++ b/waku/v2/protocol/waku_store/client.nim
@@ -49,7 +49,7 @@ proc query*(w: WakuStoreClient, req: HistoryQuery, peer: RemotePeerInfo): Future
   let rpc = HistoryRPC(requestId: generateRequestId(w.rng), query: req)
   await connection.writeLP(rpc.encode().buffer)
 
-  var message = await connOpt.get().readLp(MaxRpcSize.int)
+  var message = await connection.readLp(MaxRpcSize.int)
   let response = HistoryRPC.init(message)
 
   if response.isErr():
@@ -114,6 +114,7 @@ proc queryLoop*(w: WakuStoreClient, req: HistoryQuery, peers: seq[RemotePeerInfo
 
 proc setPeer*(ws: WakuStoreClient, peer: RemotePeerInfo) =
   ws.peerManager.addPeer(peer, WakuStoreCodec)
+  waku_store_peers.inc()
 
 proc query*(w: WakuStoreClient, req: HistoryQuery): Future[WakuStoreResult[HistoryResponse]] {.async, gcsafe.} =
   # TODO: We need to be more stratigic about which peers we dial. Right now we just set one on the service.


### PR DESCRIPTION
This refactoring was hastened due to the upcoming Dandelion++ support for the waku lightpush protocol.

- [x] Split waku lightpush protocol on server and client modules
- [x] Change message push handling to support any kind of handling (not only waku relay publishing)
- [x] Update waku node accordingly
- [x] Update tests accordingly   