### PR TITLE
feat(wakunode2): add nwaku agent-string to switch

### DIFF
--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -36,6 +36,11 @@ type
       desc: "prints the version"
       defaultValue: false
       name: "version" }: bool
+
+    agentString* {.
+      defaultValue: "nwaku",
+      desc: "Node agent string which is used as identifier in network"
+      name: "agent-string" .}: string
     
     nodekey* {.
       desc: "P2P node private key as 64 char hex string.",

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -283,7 +283,8 @@ proc initNode(conf: WakuNodeConf,
                         dnsResolver,
                         conf.relayPeerExchange, # We send our own signed peer record when peer exchange enabled
                         dns4DomainName,
-                        discv5UdpPort
+                        discv5UdpPort,
+                        some(conf.agentString)
                         )
   except:
     return err("failed to create waku node instance: " & getCurrentExceptionMsg())

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -209,3 +209,39 @@ procSuite "WakuNode":
     check:
       node.announcedAddresses.len == 1
       node.announcedAddresses.contains(expectedDns4Addr)
+
+   
+  asyncTest "Agent string is set and advertised correctly":
+    let
+      # custom agent string
+      expectedAgentString1 = "node1-agent-string"
+
+      # bump when updating nim-libp2p
+      expectedAgentString2 = "nim-libp2p/0.0.1"
+    let
+      # node with custom agent string
+      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000),
+                           agentString = some(expectedAgentString1))
+
+      # node with default agent string from libp2p
+      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+
+    await node1.start()
+    await node1.mountRelay()
+
+    await node2.start()
+    await node2.mountRelay()
+
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+    await node2.connectToNodes(@[node1.switch.peerInfo.toRemotePeerInfo()])
+
+    let node1Agent = node2.switch.peerStore[AgentBook][node1.switch.peerInfo.toRemotePeerInfo().peerId]
+    let node2Agent = node1.switch.peerStore[AgentBook][node2.switch.peerInfo.toRemotePeerInfo().peerId]
+
+    check:
+      node1Agent == expectedAgentString1
+      node2Agent == expectedAgentString2
+
+    await allFutures(node1.stop(), node2.stop())

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -129,7 +129,9 @@ proc new*(T: type WakuNode,
           nameResolver: NameResolver = nil,
           sendSignedPeerRecord = false,
           dns4DomainName = none(string),
-          discv5UdpPort = none(Port)): T {.raises: [Defect, LPError, IOError, TLSStreamProtocolError].} =
+          discv5UdpPort = none(Port),
+          agentString = none(string), # defaults to nim-libp2p version
+          ): T {.raises: [Defect, LPError, IOError, TLSStreamProtocolError].} =
   ## Creates a Waku Node instance.
 
   ## Initialize addresses
@@ -198,7 +200,8 @@ proc new*(T: type WakuNode,
     secureKeyPath = secureKey,
     secureCertPath = secureCert,
     nameResolver = nameResolver,
-    sendSignedPeerRecord = sendSignedPeerRecord
+    sendSignedPeerRecord = sendSignedPeerRecord,
+    agentString = agentString
   )
   
   let wakuNode = WakuNode(

--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -70,7 +70,9 @@ proc newWakuSwitch*(
     sendSignedPeerRecord = false,
     wssEnabled: bool = false,
     secureKeyPath: string = "",
-    secureCertPath: string = ""): Switch
+    secureCertPath: string = "",
+    agentString = none(string), # defaults to nim-libp2p version
+    ): Switch
     {.raises: [Defect, IOError, LPError].} =
 
     var b = SwitchBuilder
@@ -86,6 +88,8 @@ proc newWakuSwitch*(
       .withNameResolver(nameResolver)
       .withSignedPeerRecord(sendSignedPeerRecord)
 
+    if agentString.isSome():
+      b = b.withAgentVersion(agentString.get())
     if privKey.isSome():
       b = b.withPrivateKey(privKey.get())
     if wsAddress.isSome():


### PR DESCRIPTION
Closes #1242

Description:
* Set `nwaku` as default libp2p `UserAgent` used by `identify` protocol.
* This parameter can be changed with a CLI flag.
* If the flag is not provided, the default libp2p value is used (the one we currently had)
* Tests testing the change
