### PR TITLE
chore(node): waku node code reorganization

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -67,7 +67,7 @@ type Chat = ref object
 
 type
   PrivateKey* = crypto.PrivateKey
-  Topic* = waku_node.Topic
+  Topic* = waku_node.PubsubTopic
 
 #####################
 ## chat2 protobufs ##

--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -51,7 +51,7 @@ type
   WakuBridge* = ref object of RootObj
     nodev1*: EthereumNode
     nodev2*: WakuNode
-    nodev2PubsubTopic: waku_node.Topic # Pubsub topic to bridge to/from
+    nodev2PubsubTopic: waku_node.PubsubTopic # Pubsub topic to bridge to/from
     seen: seq[hashes.Hash] # FIFO queue of seen WakuMessages. Used for deduplication.
     rng: ref HmacDrbgContext
     v1Pool: seq[Node] # Pool of v1 nodes for possible connections
@@ -228,7 +228,7 @@ proc new*(T: type WakuBridge,
           nodev2ExtIp = none[ValidIpAddress](), nodev2ExtPort = none[Port](),
           nameResolver: NameResolver = nil,
           # Bridge configuration
-          nodev2PubsubTopic: waku_node.Topic,
+          nodev2PubsubTopic: waku_node.PubsubTopic,
           v1Pool: seq[Node] = @[],
           targetV1Peers = 0): T
   {.raises: [Defect,IOError, TLSStreamProtocolError, LPError].} =

--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -29,8 +29,8 @@ proc runBackground() {.async.} =
   await node.mountRelay()
 
   # Subscribe to a topic
-  let topic = cast[Topic]("foobar")
-  proc handler(topic: Topic, data: seq[byte]) {.async, gcsafe.} =
+  let topic = cast[PubsubTopic]("foobar")
+  proc handler(topic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
     let message = WakuMessage.init(data).value
     let payload = cast[string](message.payload)
     info "Hit subscribe handler", topic=topic, payload=payload, contentTopic=message.contentTopic


### PR DESCRIPTION
This is a gardening PR 🌳🧑‍🌾

- [x] Rename the `string` type alias from the ambiguous `Topic` name to `PubsubTopic`
- [x] Reorganize `waku_node` module code. Collocate and group together related methods to improve code readability
- [x] Unify `setPeer` methods. Now support multiaddress strings and `RemotePeerInfo` type as input parameter

NOTE: These changes are necessary for the coming protocol client PRs