### PR TITLE
fix(rln-relay): readPersistentRlnCredentials returns a result

### DIFF
--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -1008,7 +1008,12 @@ suite "Waku rln relay":
     # Write RLN credentials
     writeFile(path, pretty(%rlnMembershipCredentials))
 
-    var credentials = readPersistentRlnCredentials(path)
+    let credentialsRes = readPersistentRlnCredentials(path)
+
+    require:
+      credentialsRes.isOk()
+
+    let credentials = credentialsRes.get()
 
     check:
       credentials.membershipKeyPair == k

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1155,19 +1155,16 @@ proc readPersistentRlnCredentials*(path: string) : RlnRelayResult[RlnMembershipC
     try:
       entireRlnCredentialsFile = readFile(path)
     except Exception as err:
-      error "Error while reading the rln credentials file", err=err.msg
       return err("Error while reading the rln credentials file: " & err.msg)
     var jsonObject: JsonNode
     try:
       let jsonObject = parseJson(entireRlnCredentialsFile)
     except Exception as err:
-      error "Error while parsing the rln credentials file", err=err.msg
       return err("Error while parsing the rln credentials file: " & err.msg)
     var rlnCredentials: RlnMembershipCredentials
     try:
       rlnCredentials = jsonObject.to(RlnMembershipCredentials)
     except Exception as err:
-      error "Error while converting the rln credentials file to RlnMembershipCredentials object", err=err.msg
       return err("Error while converting the rln credentials file to RlnMembershipCredentials object: " & err.msg)
     
   debug "Deserialized Rln credentials", rlnCredentials=rlnCredentials
@@ -1238,6 +1235,7 @@ proc mount(node: WakuNode,
         # retrieve rln-relay credential
         let credentialsRes = readPersistentRlnCredentials(rlnRelayCredPath)
         if credentialsRes.isErr():
+          error "failed to read rln-relay credentials", err=credentialsRes.error()
           return err(credentialsRes.error())
         credentials = some(credentialsRes.get())
  


### PR DESCRIPTION
Closes #1053, part of the effort to convert all errors thrown in the waku-rln-relay 
protocol to results, and eventually enums 
(https://github.com/status-im/nwaku/issues/1245).

`readPersistentRlnCredentials` could raise OSErrors, IOErrors and Exceptions, and now 
returns an RlnRelayResult.
