### PR TITLE
feat(testlib): add enable/disable test debug utils

### DIFF
--- a/tests/v2/testlib/testutils.nim
+++ b/tests/v2/testlib/testutils.nim
@@ -1,0 +1,12 @@
+template suitex*(name: string, body: untyped) = discard
+template xsuite*(name: string, body: untyped) = discard
+
+template testx*(name: string, body: untyped) = discard
+template xtest*(name: string, body: untyped) = discard
+
+template procSuitex*(name: string, body: untyped) = discard
+template xprocSuite*(name: string, body: untyped) = discard
+
+template asyncTestx*(name: string, body: untyped) = discard
+template xasyncTest*(name: string, body: untyped) = discard
+  


### PR DESCRIPTION
Following Javascript's Jest idea of _disabling a test by adding an 'x' before/after the test keyword_ (see [Jest docs](https://jestjs.io/docs/next/api#describeskipname-fn:~:text=Also%20under%20the%20aliases%3A%20it.skip(name%2C%20fn)%2C%20xit(name%2C%20fn)%2C%20and%20xtest(name%2C%20fn))):

> When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to delete this code, you can use test.skip to specify some tests to skip.

So in our case this is how to use the new test debug utils:

1. Import the `./testlib/testutils` module in your test suite file
2. Add a 'x' either before or after the test case/suite keyword: `xtest`, `xasyncTest`, `xsuite`, `xprocSuite`, etc.
3. Run the test suite. The tests you marked with an ✖️ won't be executed.

**IMPORTANT:** Do not forget to re-enable the test cases disabled during your debugging session before committing your changes.