### PR TITLE
chore(common): move sqlite module to common module

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -18,13 +18,14 @@ import
   libp2p/transports/[transport, wstransport],
   libp2p/nameresolving/dnsresolver
 import
+  ../../waku/common/sqlite,
+  ../../waku/common/utils/nat,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_peer_exchange,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/dnsdisc/waku_dnsdisc,
   ../../waku/v2/node/discv5/waku_discv5,
-  ../../waku/v2/node/storage/sqlite,
   ../../waku/v2/node/storage/migration,
   ../../waku/v2/node/storage/peer/waku_peer_storage,
   ../../waku/v2/node/storage/message/waku_store_queue,
@@ -37,7 +38,6 @@ import
   ../../waku/v2/node/waku_metrics,
   ../../waku/v2/utils/peers,
   ../../waku/v2/utils/wakuenr,
-  ../../waku/common/utils/nat,
   ./wakunode2_setup_rest,
   ./wakunode2_setup_rpc,
   ./config

--- a/tests/v2/test_message_store_sqlite.nim
+++ b/tests/v2/test_message_store_sqlite.nim
@@ -1,15 +1,14 @@
 {.used.}
 
 import
-  std/[unittest, options, tables, sets, times, strutils, sequtils, os],
+  std/[unittest, options, sequtils],
   stew/byteutils,
-  chronos,
-  chronicles
+  chronos
 import
+  ../../waku/common/sqlite,
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/storage/message/message_retention_policy,
   ../../waku/v2/node/storage/message/message_retention_policy_capacity,
-  ../../waku/v2/node/storage/sqlite,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store/pagination,
   ../../waku/v2/utils/time,

--- a/tests/v2/test_message_store_sqlite_query.nim
+++ b/tests/v2/test_message_store_sqlite_query.nim
@@ -1,16 +1,14 @@
 {.used.}
 
 import
-  std/[options, tables, sets, strutils, sequtils, algorithm],
+  std/[options, sequtils, algorithm],
   unittest2,
-  chronos,
-  chronicles
+  chronos
 import
+  ../../waku/common/sqlite,
   ../../waku/v2/node/storage/message/sqlite_store,
-  ../../waku/v2/node/storage/sqlite,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store/pagination,
-  ../../waku/v2/utils/time,
   ./utils,
   ./testlib/common
 

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -1,11 +1,13 @@
 {.used.}
 
 import
-  std/[options, sets, tables, sequtils],
+  std/[options, tables, sequtils],
+  stew/shims/net as stewNet,
   chronicles,
-  testutils/unittests, stew/shims/net as stewNet,
+  testutils/unittests,
   json_rpc/[rpcserver, rpcclient],
-  eth/[keys, rlp], eth/common/eth_types,
+  eth/keys,
+  eth/common/eth_types,
   libp2p/[builders, switch, multiaddress],
   libp2p/protobuf/minprotobuf,
   libp2p/stream/[bufferstream, connection],
@@ -13,14 +15,15 @@ import
   libp2p/protocols/pubsub/pubsub,
   libp2p/protocols/pubsub/rpc/message
 import
+  ../../waku/common/sqlite,
+  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/storage/peer/waku_peer_storage,
+  ../../waku/v2/node/waku_node,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_swap/waku_swap,
-  ../../waku/v2/node/peer_manager/peer_manager,
-  ../../waku/v2/node/storage/peer/waku_peer_storage,
-  ../../waku/v2/node/waku_node,
   ../test_helpers
 
 procSuite "Peer Manager":
@@ -171,7 +174,7 @@ procSuite "Peer Manager":
 
   asyncTest "Peer manager can use persistent storage and survive restarts":
     let
-      database = SqliteDatabase.init("1", inMemory = true)[]
+      database = SqliteDatabase.new(":memory:")[]
       storage = WakuPeerStorage.new(database)[]
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
@@ -219,7 +222,7 @@ procSuite "Peer Manager":
 
 asyncTest "Peer manager support multiple protocol IDs when reconnecting to peers":
     let
-      database = SqliteDatabase.init("2", inMemory = true)[]
+      database = SqliteDatabase.new(":memory:")[]
       storage = WakuPeerStorage.new(database)[]
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),

--- a/tests/v2/test_peer_storage.nim
+++ b/tests/v2/test_peer_storage.nim
@@ -4,6 +4,7 @@ import
   std/[unittest, sets],
   libp2p/crypto/crypto
 import
+  ../../waku/common/sqlite,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/storage/peer/waku_peer_storage,
   ../test_helpers

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -8,20 +8,20 @@ import
   chronicles,
   libp2p/crypto/crypto
 import
-  ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/protocol/waku_store,
-  ../../waku/v2/protocol/waku_store/client,
-  ../../waku/v2/node/storage/sqlite,
+  ../../waku/common/sqlite,
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/protocol/waku_message,
+  ../../waku/v2/protocol/waku_store,
+  ../../waku/v2/protocol/waku_store/client,
   ../../waku/v2/utils/time,
   ./testlib/common,
   ./testlib/switch
 
 
 proc newTestDatabase(): SqliteDatabase =
-  SqliteDatabase.init("", inMemory = true).tryGet()
+  SqliteDatabase.new(":memory:").tryGet()
 
 proc newTestMessageStore(): MessageStore =
   let database = newTestDatabase()

--- a/tests/v2/test_waku_store_client.nim
+++ b/tests/v2/test_waku_store_client.nim
@@ -1,25 +1,25 @@
 {.used.}
 
 import
-  std/[options, tables, sets],
+  std/[options, tables],
   testutils/unittests, 
   chronos, 
   chronicles,
   libp2p/crypto/crypto
 import
+  ../../waku/common/sqlite,
+  ../../waku/v2/node/storage/message/sqlite_store,
+  ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_store/client,
   ../../waku/v2/protocol/waku_store/protocol_metrics,
-  ../../waku/v2/node/storage/sqlite,
-  ../../waku/v2/node/storage/message/sqlite_store,
-  ../../waku/v2/node/peer_manager/peer_manager,
   ./testlib/common,
   ./testlib/switch
 
 
 proc newTestDatabase(): SqliteDatabase =
-  SqliteDatabase.init("", inMemory = true).tryGet()
+  SqliteDatabase.new(":memory:").tryGet()
 
 proc newTestStore(): MessageStore =
   let database = newTestDatabase()

--- a/tests/v2/test_waku_store_resume.nim
+++ b/tests/v2/test_waku_store_resume.nim
@@ -7,17 +7,17 @@ import
   chronicles,
   libp2p/crypto/crypto
 import
-  ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/protocol/waku_store,
-  ../../waku/v2/node/storage/sqlite,
+  ../../waku/common/sqlite,
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/protocol/waku_message,
+  ../../waku/v2/protocol/waku_store,
   ./testlib/common,
   ./testlib/switch
 
 
 proc newTestDatabase(): SqliteDatabase =
-  SqliteDatabase.init("", inMemory = true).tryGet()
+  SqliteDatabase.new("memory:").tryGet()
 
 proc newTestMessageStore(): MessageStore =
   let database = newTestDatabase()

--- a/tests/v2/test_wakunode_store.nim
+++ b/tests/v2/test_wakunode_store.nim
@@ -14,7 +14,7 @@ import
   libp2p/protocols/pubsub/pubsub,
   libp2p/protocols/pubsub/gossipsub
 import
-  ../../waku/v2/node/storage/sqlite,
+  ../../waku/common/sqlite,
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/protocol/waku_message,

--- a/waku/common/sqlite.nim
+++ b/waku/common/sqlite.nim
@@ -118,16 +118,6 @@ proc new*(T: type SqliteDatabase, path: string, readOnly=false): DatabaseResult[
 
   ok(SqliteDatabase(env: env.release))
 
-proc init*(
-    T: type SqliteDatabase,
-    basePath: string,
-    name: string = "store",
-    readOnly = false,
-    inMemory = false): DatabaseResult[T] {.deprecated: "use `SqliteDatabase.new()` instead".} =
-  let path = if inMemory: ":memory:"
-             else: basePath / name & ".sqlite3"
-  SqliteDatabase.new(path, readOnly)
-
 
 template prepare*(env: Sqlite, q: string, cleanup: untyped): ptr sqlite3_stmt =
   var s: ptr sqlite3_stmt

--- a/waku/v2/node/storage/message/sqlite_store/queries.nim
+++ b/waku/v2/node/storage/message/sqlite_store/queries.nim
@@ -5,7 +5,7 @@ import
   stew/[results, byteutils],
   sqlite3_abi
 import
-  ../../sqlite, 
+  ../../../../../common/sqlite, 
   ../../../../protocol/waku_message,
   ../../../../utils/time
 

--- a/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
+++ b/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
@@ -3,15 +3,15 @@
 {.push raises: [Defect].}
 
 import 
-  std/[options, tables, sequtils, algorithm, times],
+  std/[options, tables],
   stew/[byteutils, results],
   chronicles
 import
+  ../../../../../common/sqlite,
   ../../../../protocol/waku_message,
   ../../../../protocol/waku_store/pagination,
   ../../../../protocol/waku_store/message_store,
   ../../../../utils/time,
-  ../../sqlite,
   ./queries
 
 logScope:

--- a/waku/v2/node/storage/migration.nim
+++ b/waku/v2/node/storage/migration.nim
@@ -3,7 +3,7 @@ import
   stew/results,
   chronicles
 import
-  ./sqlite,
+  ../../../common/sqlite,
   ./migration/migration_types,
   ./migration/migration_utils
 

--- a/waku/v2/node/storage/peer/waku_peer_storage.nim
+++ b/waku/v2/node/storage/peer/waku_peer_storage.nim
@@ -2,12 +2,13 @@
 
 import
   std/sets, 
-  sqlite3_abi,
-  libp2p/protobuf/minprotobuf,
   stew/results,
-  ./peer_storage,
-  ../sqlite,
-  ../../peer_manager/waku_peer_store
+  sqlite3_abi,
+  libp2p/protobuf/minprotobuf
+import
+  ../../../../common/sqlite,
+  ../../peer_manager/waku_peer_store,
+  ./peer_storage
 
 export sqlite
 


### PR DESCRIPTION
Another gardening PR 🌳

- [x] Move `sqlite` database module to `common` module
- [x] Remve deprecated `sqlite.init()` module