### PR TITLE
fix(rln-relay): RangeDefect test

### DIFF
--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -820,7 +820,7 @@ suite "Waku rln relay":
     debug "encoded and decode time", epoch = epoch, epochBytes = epochBytes,
       decodedEpoch = decodedEpoch
 
-  test "Epoch comparison":
+  test "Epoch comparison, epoch1 > epoch2":
     # check edge cases
     let
       time1 = uint64.high
@@ -828,8 +828,8 @@ suite "Waku rln relay":
       epoch1 = time1.toEpoch()
       epoch2 = time2.toEpoch()
     check:
-      diff(epoch1, epoch2) == int64(1)
-      diff(epoch2, epoch1) == int64(-1)
+      diff(epoch1, epoch2) == uint64(1)
+      diff(epoch2, epoch1) == uint64(1)
 
   test "updateLog and hasDuplicate tests":
     let

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -828,8 +828,8 @@ suite "Waku rln relay":
       epoch1 = time1.toEpoch()
       epoch2 = time2.toEpoch()
     check:
-      diff(epoch1, epoch2) == uint64(1)
-      diff(epoch2, epoch1) == uint64(1)
+      absDiff(epoch1, epoch2) == uint64(1)
+      absDiff(epoch2, epoch1) == uint64(1)
 
   test "updateLog and hasDuplicate tests":
     let

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_constants.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_constants.nim
@@ -458,4 +458,4 @@ const EpochUnitSeconds* = float64(10) # the rln-relay epoch length in seconds
 const MaxClockGapSeconds* = 20.0 # the maximum clock difference between peers in seconds
                                     
 # maximum allowed gap between the epochs of messages' RateLimitProofs
-const MaxEpochGap* = int64(MaxClockGapSeconds/EpochUnitSeconds)
+const MaxEpochGap* = uint64(MaxClockGapSeconds/EpochUnitSeconds)

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -785,8 +785,8 @@ proc getCurrentEpoch*(): Epoch =
   ## gets the current rln Epoch time
   return calcEpoch(epochTime())
 
-proc diff*(e1, e2: Epoch): uint64 =
-  ## returns the difference between the two rln `Epoch`s `e1` and `e2`
+proc absDiff*(e1, e2: Epoch): uint64 =
+  ## returns the absolute difference between the two rln `Epoch`s `e1` and `e2`
   ## i.e., e1 - e2
 
   # convert epochs to their corresponding unsigned numerical values
@@ -826,7 +826,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
   let
     msgEpoch = msg.proof.epoch
     # calculate the gaps
-    gap = diff(epoch, msgEpoch)
+    gap = absDiff(epoch, msgEpoch)
 
   debug "message epoch", msgEpoch = fromEpoch(msgEpoch)
 

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -785,20 +785,20 @@ proc getCurrentEpoch*(): Epoch =
   ## gets the current rln Epoch time
   return calcEpoch(epochTime())
 
-proc safeIntCast(x: uint64): int64 =
-  if x < uint64(int64.high): return int64(x)
-  else: return -int64(bitnot(x)) - 1
-
-proc diff*(e1, e2: Epoch): int64 =
+proc diff*(e1, e2: Epoch): uint64 =
   ## returns the difference between the two rln `Epoch`s `e1` and `e2`
   ## i.e., e1 - e2
 
-  # convert epochs to their corresponding unsigned numerical values,
-  # then safely cast them to signed int64
+  # convert epochs to their corresponding unsigned numerical values
   let
-    epoch1 = safeIntCast(fromEpoch(e1))
-    epoch2 = safeIntCast(fromEpoch(e2))
-  return epoch1 - epoch2
+    epoch1 = fromEpoch(e1)
+    epoch2 = fromEpoch(e2)
+  
+  # Manually perform an `abs` calculation
+  if epoch1 > epoch2:
+    return epoch1 - epoch2
+  else:
+    return epoch2 - epoch1
 
 
 proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
@@ -831,7 +831,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
   debug "message epoch", msgEpoch = fromEpoch(msgEpoch)
 
   # validate the epoch
-  if abs(gap) > MaxEpochGap:
+  if gap > MaxEpochGap:
     # message's epoch is too old or too ahead
     # accept messages whose epoch is within +-MaxEpochGap from the current epoch
     debug "invalid message: epoch gap exceeds a threshold", gap = gap,

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1,7 +1,7 @@
 {.push raises: [Defect].}
 
 import
-  std/[sequtils, tables, times, streams, os, deques, bitops],
+  std/[sequtils, tables, times, os, deques],
   chronicles, options, chronos, stint,
   confutils,
   web3, json,

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -793,7 +793,10 @@ proc diff*(e1, e2: Epoch): int64 =
   let
     epoch1 = fromEpoch(e1)
     epoch2 = fromEpoch(e2)
-  return int64(epoch1) - int64(epoch2)
+  # Cannot use `abs` here because it is not available for `uint64`
+  if epoch1 > epoch2: return int64(epoch1 - epoch2)
+  else: return int64(epoch2 - epoch1) * -1
+
 
 proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
     timeOption: Option[float64] = none(float64)): MessageValidationResult =


### PR DESCRIPTION
This should resolve the broken ci tests for the epoch comparison in rln-relay.

Compares the epochs and returns the appropriate value.
