### PR TITLE
refactor(peer-exchange): move peer management to waku_node module

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -433,7 +433,7 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
   # waku peer exchange setup
   if (conf.peerExchangeNode != "") or (conf.peerExchange):
     try:
-      await mountWakuPeerExchange(node)
+      await mountPeerExchange(node)
     except:
       return err("failed to mount waku peer-exchange protocol: " & getCurrentExceptionMsg())
 

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -124,14 +124,14 @@ procSuite "Waku Peer Exchange":
     await allFutures([node1.startDiscv5(), node2.startDiscv5()])
 
     # Mount peer exchange
-    await node1.mountWakuPeerExchange()
-    await node3.mountWakuPeerExchange()
+    await node1.mountPeerExchange()
+    await node3.mountPeerExchange()
 
     await sleepAsync(3000.millis) # Give the algorithm some time to work its magic
 
     asyncSpawn node1.wakuPeerExchange.runPeerExchangeDiscv5Loop()
 
-    node3.wakuPeerExchange.setPeer(node1.switch.peerInfo.toRemotePeerInfo())
+    node3.setPeerExchangePeer(node1.peerInfo.toRemotePeerInfo())
 
     ## When
     discard waitFor node3.wakuPeerExchange.request(1)

--- a/waku/v2/protocol/waku_peer_exchange.nim
+++ b/waku/v2/protocol/waku_peer_exchange.nim
@@ -3,11 +3,8 @@
 import
   ./waku_peer_exchange/rpc,
   ./waku_peer_exchange/rpc_codec,
-  ./waku_peer_exchange/protocol,
-  ./waku_peer_exchange/client
-
+  ./waku_peer_exchange/protocol
 export
   rpc,
   rpc_codec,
-  protocol,
-  client
+  protocol

--- a/waku/v2/protocol/waku_peer_exchange/client.nim
+++ b/waku/v2/protocol/waku_peer_exchange/client.nim
@@ -1,9 +1,0 @@
-{.push raises: [Defect].}
-
-import 
-  std/[tables, sequtils],
-  chronicles
-import
-  ../waku_message,
-  ./rpc
-


### PR DESCRIPTION
For consistency with the other protocols:

- [x] Move set peer logic to waku node
- [x] Move peer exchange nodes metric to waku node module
- [x] Uniformize the first argument name in `protocol.nim`
- [x] Remove the unnecessary client module
- [x] Update tests accordingly 