### PR TITLE
fix: replace TaintedString type deprecated in nim 1.5

### DIFF
--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -297,7 +297,7 @@ type
       name: "rln-relay-cred-password" }: string
     
 # NOTE: Keys are different in nim-libp2p
-proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =
+proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
   try:
     let key = SkPrivateKey.init(utils.fromHex(p)).tryGet()
     # XXX: Here at the moment
@@ -305,25 +305,25 @@ proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid private key")
 
-proc completeCmdArg*(T: type crypto.PrivateKey, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type ValidIpAddress, p: TaintedString): T =
+proc parseCmdArg*(T: type ValidIpAddress, p: string): T =
   try:
     result = ValidIpAddress.init(p)
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid IP address")
 
-proc completeCmdArg*(T: type ValidIpAddress, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type ValidIpAddress, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type Port, p: TaintedString): T =
+proc parseCmdArg*(T: type Port, p: string): T =
   try:
     result = Port(parseInt(p))
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid Port number")
 
-proc completeCmdArg*(T: type Port, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type Port, val: string): seq[string] =
   return @[]
 
 func defaultListenAddress*(conf: Chat2Conf): ValidIpAddress =

--- a/apps/chat2bridge/config_chat2bridge.nim
+++ b/apps/chat2bridge/config_chat2bridge.nim
@@ -129,33 +129,33 @@ type
       defaultValue: "/toy-chat/2/huilong/proto"
       name: "content-topic" }: string
 
-proc parseCmdArg*(T: type keys.KeyPair, p: TaintedString): T =
+proc parseCmdArg*(T: type keys.KeyPair, p: string): T =
   try:
     let privkey = keys.PrivateKey.fromHex(string(p)).tryGet()
     result = privkey.toKeyPair()
   except CatchableError:
     raise newException(ConfigurationError, "Invalid private key")
 
-proc completeCmdArg*(T: type keys.KeyPair, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type keys.KeyPair, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =
+proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
   let key = SkPrivateKey.init(p)
   if key.isOk():
     crypto.PrivateKey(scheme: Secp256k1, skkey: key.get())
   else:
     raise newException(ConfigurationError, "Invalid private key")
 
-proc completeCmdArg*(T: type crypto.PrivateKey, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type ValidIpAddress, p: TaintedString): T =
+proc parseCmdArg*(T: type ValidIpAddress, p: string): T =
   try:
     result = ValidIpAddress.init(p)
   except CatchableError:
     raise newException(ConfigurationError, "Invalid IP address")
 
-proc completeCmdArg*(T: type ValidIpAddress, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type ValidIpAddress, val: string): seq[string] =
   return @[]
 
 func defaultListenAddress*(conf: Chat2MatterbridgeConf): ValidIpAddress =

--- a/apps/wakubridge/config_bridge.nim
+++ b/apps/wakubridge/config_bridge.nim
@@ -151,33 +151,33 @@ type
       defaultValue: "/waku/2/default-waku/proto"
       name: "bridge-pubsub-topic" }: string
 
-proc parseCmdArg*(T: type keys.KeyPair, p: TaintedString): T =
+proc parseCmdArg*(T: type keys.KeyPair, p: string): T =
   try:
     let privkey = keys.PrivateKey.fromHex(string(p)).tryGet()
     result = privkey.toKeyPair()
   except CatchableError:
     raise newException(ConfigurationError, "Invalid private key")
 
-proc completeCmdArg*(T: type keys.KeyPair, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type keys.KeyPair, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =
+proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
   let key = SkPrivateKey.init(p)
   if key.isOk():
     crypto.PrivateKey(scheme: Secp256k1, skkey: key.get())
   else:
     raise newException(ConfigurationError, "Invalid private key")
 
-proc completeCmdArg*(T: type crypto.PrivateKey, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type ValidIpAddress, p: TaintedString): T =
+proc parseCmdArg*(T: type ValidIpAddress, p: string): T =
   try:
     result = ValidIpAddress.init(p)
   except CatchableError:
     raise newException(ConfigurationError, "Invalid IP address")
 
-proc completeCmdArg*(T: type ValidIpAddress, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type ValidIpAddress, val: string): seq[string] =
   return @[]
 
 func defaultListenAddress*(conf: WakuNodeConf): ValidIpAddress =

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -436,7 +436,7 @@ type
       name: "websocket-secure-cert-path"}: string
 
 # NOTE: Keys are different in nim-libp2p
-proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =
+proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
   try:
     let key = SkPrivateKey.init(utils.fromHex(p)).tryGet()
     # XXX: Here at the moment
@@ -444,25 +444,25 @@ proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid private key")
 
-proc completeCmdArg*(T: type crypto.PrivateKey, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type ValidIpAddress, p: TaintedString): T =
+proc parseCmdArg*(T: type ValidIpAddress, p: string): T =
   try:
     result = ValidIpAddress.init(p)
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid IP address")
 
-proc completeCmdArg*(T: type ValidIpAddress, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type ValidIpAddress, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type Port, p: TaintedString): T =
+proc parseCmdArg*(T: type Port, p: string): T =
   try:
     result = Port(parseInt(p))
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid Port number")
 
-proc completeCmdArg*(T: type Port, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type Port, val: string): seq[string] =
   return @[]
 
 proc defaultListenAddress*(): ValidIpAddress =

--- a/examples/v1/config_example.nim
+++ b/examples/v1/config_example.nim
@@ -45,21 +45,21 @@ type
         defaultValue: KeyPair.random(keys.newRng()[])
         name: "nodekey" .}: KeyPair
 
-proc parseCmdArg*(T: type KeyPair, p: TaintedString): T =
+proc parseCmdArg*(T: type KeyPair, p: string): T =
   try:
     let privkey = PrivateKey.fromHex(string(p)).tryGet()
     result = privkey.toKeyPair()
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid private key")
 
-proc completeCmdArg*(T: type KeyPair, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type KeyPair, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type IpAddress, p: TaintedString): T =
+proc parseCmdArg*(T: type IpAddress, p: string): T =
   try:
     result = parseIpAddress(p)
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid IP address")
 
-proc completeCmdArg*(T: type IpAddress, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type IpAddress, val: string): seq[string] =
   return @[]

--- a/tools/wakucanary/wakucanary.nim
+++ b/tools/wakucanary/wakucanary.nim
@@ -51,13 +51,13 @@ type
       abbr: "l" .}: LogLevel
 
 
-proc parseCmdArg*(T: type chronos.Duration, p: TaintedString): T =
+proc parseCmdArg*(T: type chronos.Duration, p: string): T =
   try:
       result = chronos.seconds(parseInt(p))
   except CatchableError as e:
     raise newException(ConfigurationError, "Invalid timeout value")
 
-proc completeCmdArg*(T: type chronos.Duration, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type chronos.Duration, val: string): seq[string] =
   return @[]
 
 # checks if rawProtocols (skipping version) are supported in nodeProtocols

--- a/waku/v1/node/config.nim
+++ b/waku/v1/node/config.nim
@@ -144,21 +144,21 @@ type
     of genNodekey:
       discard
 
-proc parseCmdArg*(T: type KeyPair, p: TaintedString): T =
+proc parseCmdArg*(T: type KeyPair, p: string): T =
   try:
     let privkey = PrivateKey.fromHex(string(p)).tryGet()
     result = privkey.toKeyPair()
   except CatchableError:
     raise newException(ConfigurationError, "Invalid private key")
 
-proc completeCmdArg*(T: type KeyPair, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type KeyPair, val: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type IpAddress, p: TaintedString): T =
+proc parseCmdArg*(T: type IpAddress, p: string): T =
   try:
     result = parseIpAddress(p)
   except CatchableError:
     raise newException(ConfigurationError, "Invalid IP address")
 
-proc completeCmdArg*(T: type IpAddress, val: TaintedString): seq[string] =
+proc completeCmdArg*(T: type IpAddress, val: string): seq[string] =
   return @[]

--- a/waku/v2/node/discv5/waku_discv5.nim
+++ b/waku/v2/node/discv5/waku_discv5.nim
@@ -26,7 +26,7 @@ type
 # Helper functions #
 ####################
 
-proc parseBootstrapAddress(address: TaintedString):
+proc parseBootstrapAddress(address: string):
     Result[enr.Record, cstring] =
   logScope:
     address = string(address)

--- a/waku/v2/protocol/waku_swap/waku_swap_contracts.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_contracts.nim
@@ -21,7 +21,7 @@ type NodeTaskJsonResult = Result[JsonNode, string]
 const taskPrelude = "npx hardhat --network localhost "
 const cmdPrelude = "cd ../swap-contracts-module; " & taskPrelude
 
-# proc execNodeTask(taskStr: string): tuple[output: TaintedString, exitCode: int] =
+# proc execNodeTask(taskStr: string): tuple[output: string, exitCode: int] =
 #   let cmdString = $cmdPrelude & $taskStr
 #   debug "execNodeTask", cmdString
 #   return osproc.execCmdEx(cmdString)


### PR DESCRIPTION
Fixes for the following warnings:

> /Users/runner/work/nwaku/nwaku/apps/wakunode2/config.nim(439, 49) Warning: Deprecated since 1.5; TaintedString is deprecated [Deprecated]