### PR TITLE
fix(wakunode2): fix message retention policy config validation regex

### DIFF
--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -493,7 +493,7 @@ proc validateDbUrl*(val: string): ConfResult[string] =
     return err("invalid 'db url' option format: " & val)
 
 
-let StoreMessageRetentionPolicyRegex = re"^\w+:\w$"
+let StoreMessageRetentionPolicyRegex = re"^\w+:\w+$"
 
 proc validateStoreMessageRetentionPolicy*(val: string): ConfResult[string] =
   let val = val.strip()


### PR DESCRIPTION
The `wakunode2` binary was not starting due to an invalid _message retention policy_ configuration value. This fixes the bad regex (a copy-paste error 😅).