### PR TITLE
refactor(wakunode2): move configuration load logic to config module

### DIFF
--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -16,7 +16,7 @@ import
 # Node operations happens asynchronously
 proc runBackground() {.async.} =
   let
-    conf = WakuNodeConf.load()
+    conf = WakuNodeConf.load().tryGet()
     (extIp, extTcpPort, extUdpPort) = setupNat(conf.nat, clientId,
       Port(uint16(conf.tcpPort) + conf.portsShift),
       # This is actually a UDP port but we're only supplying this value


### PR DESCRIPTION
In my road to support configuring `wakunode2` via environment variables, I bring this gardening PR 🌳

- [x] Move the `WakuNodeConf.load()` to the `config` module
- [x] Make `load()` to return a `ConfResult`
- [x] Manage the `--version` option with _confutils_