### PR TITLE
chore: make log topics consistent with nim-chronicles style

### DIFF
--- a/waku/v2/node/discv5/waku_discv5.nim
+++ b/waku/v2/node/discv5/waku_discv5.nim
@@ -15,7 +15,7 @@ declarePublicGauge waku_discv5_discovered, "number of nodes discovered"
 declarePublicGauge waku_discv5_errors, "number of waku discv5 errors", ["type"]
 
 logScope:
-  topics = "wakudiscv5"
+  topics = "waku discv5"
 
 type
   WakuDiscoveryV5* = ref object

--- a/waku/v2/node/dnsdisc/waku_dnsdisc.nim
+++ b/waku/v2/node/dnsdisc/waku_dnsdisc.nim
@@ -26,7 +26,7 @@ declarePublicGauge waku_dnsdisc_discovered, "number of nodes discovered"
 declarePublicGauge waku_dnsdisc_errors, "number of waku dnsdisc errors", ["type"]
 
 logScope:
-  topics = "wakudnsdisc"
+  topics = "waku dnsdisc"
 
 type
   WakuDnsDiscovery* = object

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -17,7 +17,7 @@ import
 export jsonrpc_types
 
 logScope:
-  topics = "admin api"
+  topics = "waku node jsonrpc admin_api"
 
 const futTimeout* = 30.seconds # Max time to wait for futures
 

--- a/waku/v2/node/jsonrpc/debug_api.nim
+++ b/waku/v2/node/jsonrpc/debug_api.nim
@@ -6,7 +6,7 @@ import
   ../waku_node
 
 logScope:
-  topics = "debug api"
+  topics = "waku node jsonrpc debug_api"
 
 proc installDebugApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 

--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -14,7 +14,7 @@ import
 export jsonrpc_types
 
 logScope:
-  topics = "wakunode.rpc.filter"
+  topics = "waku node jsonrpc filter_api"
 
 
 const DefaultPubsubTopic: PubsubTopic = "/waku/2/default-waku/proto"

--- a/waku/v2/node/jsonrpc/private_api.nim
+++ b/waku/v2/node/jsonrpc/private_api.nim
@@ -14,7 +14,7 @@ import
 export waku_payload, jsonrpc_types
 
 logScope:
-  topics = "private api"
+  topics = "waku node jsonrpc private_api"
 
 const futTimeout* = 5.seconds # Max time to wait for futures
 

--- a/waku/v2/node/jsonrpc/relay_api.nim
+++ b/waku/v2/node/jsonrpc/relay_api.nim
@@ -13,7 +13,7 @@ import
 export jsonrpc_types
 
 logScope:
-  topics = "relay api"
+  topics = "waku node jsonrpc relay_api"
 
 const futTimeout* = 5.seconds # Max time to wait for futures
 const maxCache* = 30 # Max number of messages cached per topic @TODO make this configurable

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -15,7 +15,7 @@ import
 export jsonrpc_types
 
 logScope:
-  topics = "store api"
+  topics = "waku node jsonrpc store_api"
 
 proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
   const futTimeout = 5.seconds

--- a/waku/v2/node/message_cache.nim
+++ b/waku/v2/node/message_cache.nim
@@ -9,7 +9,8 @@ import
 import
   ../protocol/waku_message
 
-logScope: topics = "message_cache"
+logScope: 
+  topics = "waku node message_cache"
 
 const DefaultMessageCacheCapacity*: uint = 30 # Max number of messages cached per topic @TODO make this configurable
 

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -15,7 +15,7 @@ declarePublicCounter waku_node_conns_initiated, "Number of connections initiated
 declarePublicGauge waku_peers_errors, "Number of peer manager errors", ["type"]
 
 logScope:
-  topics = "wakupeers"
+  topics = "waku node peer_manager"
 
 type
   PeerManager* = ref object of RootObj
@@ -130,15 +130,13 @@ proc new*(T: type PeerManager, switch: Switch, storage: PeerStorage = nil): Peer
                        peerStore: WakuPeerStore.new(),
                        storage: storage)
   
-  debug "creating new PeerManager"
-
   proc peerHook(peerId: PeerID, event: ConnEvent): Future[void] {.gcsafe.} =
     onConnEvent(pm, peerId, event)
   
   pm.switch.addConnEventHandler(peerHook, ConnEventKind.Connected)
   pm.switch.addConnEventHandler(peerHook, ConnEventKind.Disconnected)
 
-  if not storage.isNil:
+  if not storage.isNil():
     debug "found persistent peer storage"
     pm.loadFromStorage() # Load previously managed peers.
   else:

--- a/waku/v2/node/rest/debug/debug_api.nim
+++ b/waku/v2/node/rest/debug/debug_api.nim
@@ -10,7 +10,8 @@ import "."/api_types
 import ".."/[serdes, utils]
 import ../../waku_node
 
-logScope: topics = "rest_api_debug"
+logScope:
+  topics = "waku node rest debug_api"
 
 
 ####  Server request handlers

--- a/waku/v2/node/rest/relay/relay_api.nim
+++ b/waku/v2/node/rest/relay/relay_api.nim
@@ -14,7 +14,8 @@ import
   ./api_types, 
   ./topic_cache
 
-logScope: topics = "rest_api_relay"
+logScope: 
+  topics = "waku node rest relay_api"
 
 
 ##### Topic cache

--- a/waku/v2/node/rest/relay/topic_cache.nim
+++ b/waku/v2/node/rest/relay/topic_cache.nim
@@ -9,7 +9,8 @@ import
   ../../../protocol/waku_message,
   ../../message_cache
 
-logScope: topics = "rest_api_relay_topiccache"
+logScope: 
+  topics = "waku node rest relay_api"
 
 export message_cache
 

--- a/waku/v2/node/rest/serdes.nim
+++ b/waku/v2/node/rest/serdes.nim
@@ -9,7 +9,8 @@ import
   json_serialization/std/[options, net, sets],
   presto/common
 
-logScope: topics = "rest_api_serdes"
+logScope: 
+  topics = "waku node rest"
 
 Json.createFlavor RestJson
 

--- a/waku/v2/node/storage/message/message_retention_policy_capacity.nim
+++ b/waku/v2/node/storage/message/message_retention_policy_capacity.nim
@@ -8,7 +8,7 @@ import
   ./message_retention_policy
 
 logScope:
-  topics = "message_store.sqlite_store.retention_policy.capacity"
+  topics = "waku node message_store retention_policy"
 
 
 const StoreDefaultCapacity*: int = 25_000

--- a/waku/v2/node/storage/message/message_retention_policy_time.nim
+++ b/waku/v2/node/storage/message/message_retention_policy_time.nim
@@ -11,7 +11,7 @@ import
   ./message_retention_policy
 
 logScope:
-  topics = "message_store.sqlite_store.retention_policy.time"
+  topics = "waku node message_store retention_policy"
 
 
 const StoreDefaultRetentionTime*: int64 = 30.days.seconds

--- a/waku/v2/node/storage/message/queue_store/queue_store.nim
+++ b/waku/v2/node/storage/message/queue_store/queue_store.nim
@@ -14,7 +14,7 @@ import
 
 
 logScope:
-  topics = "message_store.storequeue"
+  topics = "waku node message_store storequeue"
 
 
 const StoreQueueDefaultMaxCapacity* = 25_000

--- a/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
+++ b/waku/v2/node/storage/message/sqlite_store/sqlite_store.nim
@@ -15,7 +15,7 @@ import
   ./queries
 
 logScope:
-  topics = "message_store.sqlite"
+  topics = "waku node message_store sqlite"
 
 
 proc init(db: SqliteDatabase): MessageStoreResult[void] =

--- a/waku/v2/node/waku_metrics.nim
+++ b/waku/v2/node/waku_metrics.nim
@@ -22,7 +22,7 @@ when defined(rln) or defined(rlnzerokit):
 const LogInterval = 30.seconds
 
 logScope:
-  topics = "waku.metrics"
+  topics = "waku node metrics"
 
 
 proc startMetricsServer*(serverIp: ValidIpAddress, serverPort: Port) =

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -46,7 +46,7 @@ declarePublicGauge waku_store_peers, "number of store peers"
 declarePublicGauge waku_px_peers, "number of peers (in the node's peerManager) supporting the peer exchange protocol"
 
 logScope:
-  topics = "wakunode"
+  topics = "waku node"
 
 
 # Git version in git describe format (defined compile time)

--- a/waku/v2/protocol/waku_filter/client.nim
+++ b/waku/v2/protocol/waku_filter/client.nim
@@ -19,7 +19,7 @@ import
 
 
 logScope:
-  topics = "wakufilter.client"
+  topics = "waku filter client"
 
 
 const Defaultstring = "/waku/2/default-waku/proto"

--- a/waku/v2/protocol/waku_filter/protocol.nim
+++ b/waku/v2/protocol/waku_filter/protocol.nim
@@ -16,7 +16,7 @@ import
 
 
 logScope:
-  topics = "wakufilter"
+  topics = "waku filter"
 
 
 const

--- a/waku/v2/protocol/waku_lightpush/client.nim
+++ b/waku/v2/protocol/waku_lightpush/client.nim
@@ -18,7 +18,7 @@ import
 
 
 logScope:
-  topics = "wakulightpush.client"
+  topics = "waku lightpush client"
 
 
 type WakuLightPushClient* = ref object

--- a/waku/v2/protocol/waku_lightpush/protocol.nim
+++ b/waku/v2/protocol/waku_lightpush/protocol.nim
@@ -16,7 +16,7 @@ import
 
 
 logScope:
-  topics = "wakulightpush"
+  topics = "waku lightpush"
 
 
 const WakuLightPushCodec* = "/vac/waku/lightpush/2.0.0-beta1"

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -23,7 +23,7 @@ import libp2p/protocols/secure/secure
 import ./noise_types
 
 logScope:
-  topics = "wakunoise"
+  topics = "waku noise"
 
 #################################################################
 

--- a/waku/v2/protocol/waku_noise/noise_handshake_processing.nim
+++ b/waku/v2/protocol/waku_noise/noise_handshake_processing.nim
@@ -19,7 +19,7 @@ import ./noise
 import ./noise_utils
 
 logScope:
-  topics = "wakunoise"
+  topics = "waku noise"
 
 #################################################################
 

--- a/waku/v2/protocol/waku_noise/noise_types.nim
+++ b/waku/v2/protocol/waku_noise/noise_types.nim
@@ -18,7 +18,7 @@ import libp2p/errors
 import libp2p/crypto/[crypto, chacha20poly1305, curve25519]
 
 logScope:
-  topics = "wakunoise"
+  topics = "waku noise"
 
 #################################################################
 

--- a/waku/v2/protocol/waku_noise/noise_utils.nim
+++ b/waku/v2/protocol/waku_noise/noise_utils.nim
@@ -19,7 +19,7 @@ import ./noise_types
 import ./noise
 
 logScope:
-  topics = "wakunoise"
+  topics = "waku noise"
 
 #################################################################
 

--- a/waku/v2/protocol/waku_peer_exchange/protocol.nim
+++ b/waku/v2/protocol/waku_peer_exchange/protocol.nim
@@ -24,7 +24,7 @@ declarePublicGauge waku_px_peers_cached, "number of peer exchange peer ENRs cach
 declarePublicGauge waku_px_errors, "number of peer exchange errors", ["type"]
 
 logScope:
-  topics = "wakupx"
+  topics = "waku peer_exchange"
 
 
 const

--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -8,14 +8,15 @@ else:
   {.push raises: [].}
 
 import
-  std/[tables, sets],
-  chronos, chronicles, metrics,
-  libp2p/protocols/pubsub/[pubsub, gossipsub],
-  libp2p/protocols/pubsub/rpc/messages,
+  chronos,
+  chronicles, 
+  metrics,
+  libp2p/protocols/pubsub/pubsub,
+  libp2p/protocols/pubsub/gossipsub,
   libp2p/stream/connection
 
 logScope:
-    topics = "wakurelay"
+  topics = "waku relay"
 
 const
   WakuRelayCodec* = "/vac/waku/relay/2.0.0"

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics.nim
@@ -11,7 +11,7 @@ import
 export metrics
 
 logScope:
-  topics = "waku-rln-relay.metrics"
+  topics = "waku rln_relay"
 
 func generateBucketsForHistogram*(length: int): seq[float64] =
   ## Generate a custom set of 5 buckets for a given length

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -23,7 +23,7 @@ import
   ../waku_message
 
 logScope:
-  topics = "wakurlnrelayutils"
+  topics = "waku rln_relay"
 
 type MerkleNodeResult* = RlnRelayResult[MerkleNode]
 type RateLimitProofResult* = RlnRelayResult[RateLimitProof]

--- a/waku/v2/protocol/waku_store/client.nim
+++ b/waku/v2/protocol/waku_store/client.nim
@@ -22,7 +22,7 @@ import
 
 
 logScope:
-  topics = "wakustore.client"
+  topics = "waku store client"
 
 
 type WakuStoreClient* = ref object

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -29,7 +29,7 @@ import
 
 
 logScope:
-  topics = "wakustore"
+  topics = "waku store"
 
 
 const 

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -55,7 +55,7 @@ declarePublicGauge waku_swap_messages, "number of swap messages received", ["typ
 declarePublicHistogram waku_peer_swap_account_balance, "Swap Account Balance for waku peers, aggregated into buckets based on threshold limits", buckets = swapAccountBalanceBuckets
 
 logScope:
-  topics = "wakuswap"
+  topics = "waku swap"
 
 const WakuSwapCodec* = "/vac/waku/swap/2.0.0-beta1"
 

--- a/waku/v2/protocol/waku_swap/waku_swap_contracts.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_contracts.nim
@@ -10,7 +10,7 @@ import
   chronicles, stew/results
 
 logScope:
-  topics = "wakuswapcontracts"
+  topics = "waku swap"
 
 # TODO Richer error types than string, overkill for now...
 type NodeTaskJsonResult = Result[JsonNode, string]


### PR DESCRIPTION
It all started with me looking for a way to reduce the verbosity of the test cases in the CI. I hunch that test execution time is also impacted by the immense amount of logs the code is writing to the stdout.

Diving into `nim-chronicles` code, I noticed that the topics filtering mechanism works with "whole words" separated by spaces. Checking the `nim-libp2p` code base, together with some tests passing the `-d:"chronicles_disabled_topics=libp2p,pubsubprotobuf"` flag has confirmed it.

NOTE: I also noticed that in some cases, `nim-chronicles` is not respecting the `logScope: topics = "<topics>"` statement, logging without the `topics` tags.

-----

Some of the rules in the [coding guide](https://hackmd.io/5oIVOuQcSM2WKrnDLUPcpg#Logging) might need to be updated to be compatible with `nim-chronicles`. These are the rules I have synthesized for better logging:

* Log topics should contain "whole words" separated by spaces. In the case of a composed word, it should follow the `snake_case` style.
* Log topics should be ordered from more general to less general (e.g., `waku node message_store sqlite_store`)
* The modules' log topics within `waku` module should have `waku` as the first topic. This will allow any user of waku (as a library) to mute all logs coming by filtering the `waku` topic. The `whisper` module is the exception.
* The apps' log topics should start with the name of the app (e.g., `wakunode2 rest`)
* Waku protocols' log topics should be specified without the "waku" prefix (e.g., `waku filter client`)
