### PR TITLE
chore: randomize waku tcp ports in tests

### DIFF
--- a/tests/v2/test_enr_utils.nim
+++ b/tests/v2/test_enr_utils.nim
@@ -43,7 +43,7 @@ procSuite "ENR utils":
     # Tests RFC31 encoding "happy path"
     let
       enrIp = ValidIpAddress.init("127.0.0.1")
-      enrTcpPort, enrUdpPort = Port(60000)
+      enrTcpPort, enrUdpPort = Port(61101)
       enrKey = wakuenr.crypto.PrivateKey.random(Secp256k1, rng[])[]
       wakuFlags = initWakuFlags(false, true, false, true)
       multiaddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/442/ws")[],
@@ -76,7 +76,7 @@ procSuite "ENR utils":
     # Tests that peerId is stripped of multiaddrs as per RFC31
     let
       enrIp = ValidIpAddress.init("127.0.0.1")
-      enrTcpPort, enrUdpPort = Port(60000)
+      enrTcpPort, enrUdpPort = Port(61102)
       enrKey = wakuenr.crypto.PrivateKey.random(Secp256k1, rng[])[]
       multiaddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/443/wss/p2p/16Uiu2HAm4v86W3bmT1BiH6oSPzcsSr31iDQpSN5Qa882BCjjwgrD")[]]
 

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -495,11 +495,11 @@ procSuite "Waku v2 JSON-RPC API":
   asyncTest "Private API: generate asymmetric keys and encrypt/decrypt communication":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(60000))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(62001))
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(60002))
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(62002))
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(60003), some(extIp), some(port))
+      node3 = WakuNode.new(nodeKey3, bindIp, Port(62003), some(extIp), some(port))
       pubSubTopic = "polling"
       contentTopic = DefaultContentTopic
       payload = @[byte 9]
@@ -586,11 +586,11 @@ procSuite "Waku v2 JSON-RPC API":
   asyncTest "Private API: generate symmetric keys and encrypt/decrypt communication":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(60000))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(62100))
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(60002))
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(62102))
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(60003), some(extIp), some(port))
+      node3 = WakuNode.new(nodeKey3, bindIp, Port(62103), some(extIp), some(port))
       pubSubTopic = "polling"
       contentTopic = DefaultContentTopic
       payload = @[byte 9]

--- a/tests/v2/test_peer_exchange.nim
+++ b/tests/v2/test_peer_exchange.nim
@@ -22,11 +22,11 @@ procSuite "Peer Exchange":
     let
       bindIp = ValidIpAddress.init("0.0.0.0")
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(60000))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(61100))
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(60002), sendSignedPeerRecord = true)
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(61102), sendSignedPeerRecord = true)
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(60003), sendSignedPeerRecord = true)
+      node3 = WakuNode.new(nodeKey3, bindIp, Port(61103), sendSignedPeerRecord = true)
     
     var
       peerExchangeHandler, emptyHandler: RoutingRecordsHandler

--- a/tests/v2/test_utils_peers.nim
+++ b/tests/v2/test_utils_peers.nim
@@ -13,7 +13,7 @@ suite "Utils - Peers":
   
   test "Peer info parses correctly":
     ## Given 
-    let address = "/ip4/127.0.0.1/tcp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+    let address = "/ip4/127.0.0.1/tcp/65002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
       
     ## When
     let remotePeerInfo = parseRemotePeerInfo(address)
@@ -22,11 +22,11 @@ suite "Utils - Peers":
     check:
       $(remotePeerInfo.peerId) == "16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
       $(remotePeerInfo.addrs[0][0].tryGet()) == "/ip4/127.0.0.1"
-      $(remotePeerInfo.addrs[0][1].tryGet()) == "/tcp/60002"
+      $(remotePeerInfo.addrs[0][1].tryGet()) == "/tcp/65002"
     
   test "DNS multiaddrs parsing - dns peer":
     ## Given
-    let address = "/dns/localhost/tcp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+    let address = "/dns/localhost/tcp/65012/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
 
     ## When
     let dnsPeer = parseRemotePeerInfo(address)
@@ -35,11 +35,11 @@ suite "Utils - Peers":
     check:
       $(dnsPeer.peerId) == "16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
       $(dnsPeer.addrs[0][0].tryGet()) == "/dns/localhost"
-      $(dnsPeer.addrs[0][1].tryGet()) == "/tcp/60002"
+      $(dnsPeer.addrs[0][1].tryGet()) == "/tcp/65012"
 
   test "DNS multiaddrs parsing - dnsaddr peer":
     ## Given
-    let address = "/dnsaddr/localhost/tcp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+    let address = "/dnsaddr/localhost/tcp/65022/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
     
     ## When
     let dnsAddrPeer = parseRemotePeerInfo(address)
@@ -48,11 +48,11 @@ suite "Utils - Peers":
     check:
       $(dnsAddrPeer.peerId) == "16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
       $(dnsAddrPeer.addrs[0][0].tryGet()) == "/dnsaddr/localhost"
-      $(dnsAddrPeer.addrs[0][1].tryGet()) == "/tcp/60002"
+      $(dnsAddrPeer.addrs[0][1].tryGet()) == "/tcp/65022"
 
   test "DNS multiaddrs parsing - dns4 peer":
     ## Given
-    let address = "/dns4/localhost/tcp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+    let address = "/dns4/localhost/tcp/65032/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
 
     ## When
     let dns4Peer = parseRemotePeerInfo(address)
@@ -61,11 +61,11 @@ suite "Utils - Peers":
     check:
       $(dns4Peer.peerId) == "16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
       $(dns4Peer.addrs[0][0].tryGet()) == "/dns4/localhost"
-      $(dns4Peer.addrs[0][1].tryGet()) == "/tcp/60002"
+      $(dns4Peer.addrs[0][1].tryGet()) == "/tcp/65032"
   
   test "DNS multiaddrs parsing - dns6 peer":
     ## Given
-    let address = "/dns6/localhost/tcp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+    let address = "/dns6/localhost/tcp/65042/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
 
     ## When
     let dns6Peer = parseRemotePeerInfo(address)
@@ -74,7 +74,7 @@ suite "Utils - Peers":
     check:
       $(dns6Peer.peerId) == "16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
       $(dns6Peer.addrs[0][0].tryGet()) == "/dns6/localhost"
-      $(dns6Peer.addrs[0][1].tryGet()) == "/tcp/60002"
+      $(dns6Peer.addrs[0][1].tryGet()) == "/tcp/65042"
 
   test "Multiaddr parsing should fail with invalid address":
     ## Given
@@ -86,7 +86,7 @@ suite "Utils - Peers":
 
   test "Multiaddr parsing should fail with leading whitespace":
     ## Given
-    let address = " /ip4/127.0.0.1/tcp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+    let address = " /ip4/127.0.0.1/tcp/65062/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
     
     ## Then
     expect LPError:
@@ -94,7 +94,7 @@ suite "Utils - Peers":
 
   test "Multiaddr parsing should fail with trailing whitespace":
     ## Given
-    let address = "/ip4/127.0.0.1/tcp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc "
+    let address = "/ip4/127.0.0.1/tcp/65072/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc "
     
     ## Then
     expect LPError:
@@ -102,7 +102,7 @@ suite "Utils - Peers":
 
   test "Multiaddress parsing should fail with invalid IP address":
     ## Given
-    let address = "/ip4/127.0.0.0.1/tcp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+    let address = "/ip4/127.0.0.0.1/tcp/65082/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
     
     ## Then
     expect LPError:
@@ -110,7 +110,7 @@ suite "Utils - Peers":
 
   test "Multiaddress parsing should fail with no peer ID":
     ## Given
-    let address = "/ip4/127.0.0.1/tcp/60002"
+    let address = "/ip4/127.0.0.1/tcp/65092"
     
     # Then
     expect LPError:
@@ -118,7 +118,7 @@ suite "Utils - Peers":
 
   test "Multiaddress parsing should fail with unsupported transport":
     ## Given
-    let address = "/ip4/127.0.0.1/udp/60002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+    let address = "/ip4/127.0.0.1/udp/65102/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
     
     ## Then
     expect ValueError:

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -41,7 +41,7 @@ procSuite "WakuBridge":
         powRequirement = 0.002,
         rng = rng,
         nodev2Key = nodev2Key,
-        nodev2BindIp = ValidIpAddress.init("0.0.0.0"), nodev2BindPort= Port(60000),
+        nodev2BindIp = ValidIpAddress.init("0.0.0.0"), nodev2BindPort= Port(62200),
         nodev2PubsubTopic = DefaultBridgeTopic)
     
     # Waku v1 node
@@ -49,7 +49,7 @@ procSuite "WakuBridge":
 
     # Waku v2 node
     v2NodeKey = crypto.PrivateKey.random(Secp256k1, cryptoRng[])[]
-    v2Node = WakuNode.new(v2NodeKey, ValidIpAddress.init("0.0.0.0"), Port(60002))
+    v2Node = WakuNode.new(v2NodeKey, ValidIpAddress.init("0.0.0.0"), Port(62202))
 
     contentTopic = ContentTopic("/waku/1/0x1a2b3c4d/rfc26")
     topic = [byte 0x1a, byte 0x2b, byte 0x3c, byte 0x4d]
@@ -200,7 +200,7 @@ procSuite "WakuBridge":
           powRequirement = 0.002,
           rng = rng,
           nodev2Key = nodev2Key,
-          nodev2BindIp = ValidIpAddress.init("0.0.0.0"), nodev2BindPort= Port(60000),
+          nodev2BindIp = ValidIpAddress.init("0.0.0.0"), nodev2BindPort= Port(62207),
           nodev2PubsubTopic = DefaultBridgeTopic,
           v1Pool = v1NodePool.mapIt(newNode(it.toEnode())),
           targetV1Peers = targetV1Peers)

--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -23,17 +23,17 @@ procSuite "Waku Discovery v5":
       extIp = ValidIpAddress.init("127.0.0.1")
 
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      nodeTcpPort1 = Port(60000)
+      nodeTcpPort1 = Port(61500)
       nodeUdpPort1 = Port(9000)
       node1 = WakuNode.new(nodeKey1, bindIp, nodeTcpPort1)
       
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      nodeTcpPort2 = Port(60002)
+      nodeTcpPort2 = Port(61502)
       nodeUdpPort2 = Port(9002)
       node2 = WakuNode.new(nodeKey2, bindIp, nodeTcpPort2)
 
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      nodeTcpPort3 = Port(60004)
+      nodeTcpPort3 = Port(61504)
       nodeUdpPort3 = Port(9004)
       node3 = WakuNode.new(nodeKey3, bindIp, nodeTcpPort3)
 

--- a/tests/v2/test_waku_dnsdisc.nim
+++ b/tests/v2/test_waku_dnsdisc.nim
@@ -25,13 +25,13 @@ procSuite "Waku DNS Discovery":
     let
       bindIp = ValidIpAddress.init("0.0.0.0")
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(60000))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(63500))
       enr1 = node1.enr
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(60002))
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(63502))
       enr2 = node2.enr
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(60003))
+      node3 = WakuNode.new(nodeKey3, bindIp, Port(63503))
       enr3 = node3.enr
     
     await node1.mountRelay()
@@ -66,7 +66,7 @@ procSuite "Waku DNS Discovery":
 
     let
       nodeKey4 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node4 = WakuNode.new(nodeKey4, bindIp, Port(60004))
+      node4 = WakuNode.new(nodeKey4, bindIp, Port(63504))
     
     await node4.mountRelay()
     await node4.start()

--- a/tests/v2/test_waku_keepalive.nim
+++ b/tests/v2/test_waku_keepalive.nim
@@ -19,9 +19,9 @@ procSuite "Waku Keepalive":
   asyncTest "handle ping keepalives":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(63010))
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(63012))
 
     var completionFut = newFuture[bool]()
 

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -74,17 +74,17 @@ procSuite "Waku Peer Exchange":
       extIp = ValidIpAddress.init("127.0.0.1")
 
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      nodeTcpPort1 = Port(60000)
+      nodeTcpPort1 = Port(64010)
       nodeUdpPort1 = Port(9000)
       node1 = WakuNode.new(nodeKey1, bindIp, nodeTcpPort1)
 
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      nodeTcpPort2 = Port(60002)
+      nodeTcpPort2 = Port(64012)
       nodeUdpPort2 = Port(9002)
       node2 = WakuNode.new(nodeKey2, bindIp, nodeTcpPort2)
 
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      nodeTcpPort3 = Port(60004)
+      nodeTcpPort3 = Port(64014)
       nodeUdpPort3 = Port(9004)
       node3 = WakuNode.new(nodeKey3, bindIp, nodeTcpPort3)
 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -24,8 +24,7 @@ procSuite "Waku rln relay":
   asyncTest "mount waku-rln-relay in the off-chain mode":
     let
       nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"),
-        Port(60000))
+      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60200))
     await node.start()
 
     # preparing inputs to mount rln-relay

--- a/tests/v2/test_waku_rln_relay_onchain.nim
+++ b/tests/v2/test_waku_rln_relay_onchain.nim
@@ -314,8 +314,7 @@ procSuite "Waku-rln-relay":
     # preparation ------------------------------
     let
       nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"),
-        Port(60000))
+      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60110))
     await node.start()
 
     # create current peer's pk
@@ -371,7 +370,7 @@ procSuite "Waku-rln-relay":
     # preparation ------------------------------
     let
       nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60111))
     await node.start()
 
     # deploy the contract
@@ -475,12 +474,12 @@ procSuite "Waku-rln-relay":
     # prepare two nodes
     let
       nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60112))
     await node.start()
 
     let
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60001))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60113))
     await node2.start()
 
      # create an Ethereum private key and the corresponding account 

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -23,11 +23,9 @@ procSuite "WakuNode":
   asyncTest "Protocol matcher works as expected":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        Port(60000))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(61000))
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
-        Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(61002))
       pubSubTopic = "/waku/2/default-waku/proto"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
@@ -82,14 +80,14 @@ procSuite "WakuNode":
 
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000), nameResolver = resolver)
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(61020), nameResolver = resolver)
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(61022))
 
     # Construct DNS multiaddr for node2
     let
       node2PeerId = $(node2.switch.peerInfo.peerId)
-      node2Dns4Addr = "/dns4/localhost/tcp/60002/p2p/" & node2PeerId
+      node2Dns4Addr = "/dns4/localhost/tcp/61022/p2p/" & node2PeerId
 
     await node1.mountRelay()
     await node2.mountRelay()
@@ -150,15 +148,18 @@ procSuite "WakuNode":
     expect IOError:
       # gibberish
       discard WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60000), wsBindPort = Port(8000), wssEnabled = true, secureKey = "../../waku/v2/node/key_dummy.txt")
+        bindPort = Port(61004), 
+        wsBindPort = Port(8000), 
+        wssEnabled = true, 
+        secureKey = "../../waku/v2/node/key_dummy.txt")
 
   asyncTest "Peer info updates with correct announced addresses":
     let
       nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
       bindIp = ValidIpAddress.init("0.0.0.0")
-      bindPort = Port(60000)
+      bindPort = Port(61006)
       extIp = some(ValidIpAddress.init("127.0.0.1"))
-      extPort = some(Port(60002))
+      extPort = some(Port(61008))
       node = WakuNode.new(
         nodeKey,
         bindIp, bindPort,
@@ -195,9 +196,9 @@ procSuite "WakuNode":
     let
       nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
       bindIp = ValidIpAddress.init("0.0.0.0")
-      bindPort = Port(60000)
+      bindPort = Port(61010)
       extIp = some(ValidIpAddress.init("127.0.0.1"))
-      extPort = some(Port(60002))
+      extPort = some(Port(61012))
       domainName = "example.com"
       expectedDns4Addr = MultiAddress.init("/dns4/" & domainName & "/tcp/" & $(extPort.get())).get()
       node = WakuNode.new(
@@ -221,12 +222,12 @@ procSuite "WakuNode":
     let
       # node with custom agent string
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000),
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(61014),
                            agentString = some(expectedAgentString1))
 
       # node with default agent string from libp2p
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(61016))
 
     await node1.start()
     await node1.mountRelay()

--- a/tests/v2/test_wakunode_relay.nim
+++ b/tests/v2/test_wakunode_relay.nim
@@ -32,8 +32,7 @@ procSuite "WakuNode - Relay":
   asyncTest "Relay protocol is started correctly":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        Port(60000))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60400))
 
     # Relay protocol starts if mounted after node start
 
@@ -47,7 +46,7 @@ procSuite "WakuNode - Relay":
 
     let
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60402))
 
     await node2.mountRelay()
 
@@ -66,14 +65,11 @@ procSuite "WakuNode - Relay":
   asyncTest "Messages are correctly relayed":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        Port(60000))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60410))
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
-        Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60412))
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"),
-        Port(60003))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60413))
       pubSubTopic = "test"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
@@ -125,13 +121,13 @@ procSuite "WakuNode - Relay":
     let
       # publisher node
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60420))
       # Relay node
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60422))
       # Subscriber
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60003))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60423))
 
       pubSubTopic = "test"
       contentTopic1 = ContentTopic("/waku/2/default-content/proto")
@@ -213,10 +209,10 @@ procSuite "WakuNode - Relay":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60000), wsBindPort = Port(8000), wsEnabled = true)
+        bindPort = Port(60510), wsBindPort = Port(8000), wsEnabled = true)
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60002), wsBindPort = Port(8100), wsEnabled = true)
+        bindPort = Port(60512), wsBindPort = Port(8100), wsEnabled = true)
       pubSubTopic = "test"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
@@ -257,10 +253,10 @@ procSuite "WakuNode - Relay":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60000), wsBindPort = Port(8000), wsEnabled = true)
+        bindPort = Port(60520), wsBindPort = Port(8000), wsEnabled = true)
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60002))
+        bindPort = Port(60522))
       pubSubTopic = "test"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
@@ -301,10 +297,10 @@ procSuite "WakuNode - Relay":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60000))
+        bindPort = Port(60530))
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60002), wsBindPort = Port(8100), wsEnabled = true)
+        bindPort = Port(60532), wsBindPort = Port(8100), wsEnabled = true)
       pubSubTopic = "test"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
@@ -348,10 +344,10 @@ procSuite "WakuNode - Relay":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60000), wsBindPort = Port(8000), wssEnabled = true, secureKey = KEY_PATH, secureCert = CERT_PATH)
+        bindPort = Port(60540), wsBindPort = Port(8000), wssEnabled = true, secureKey = KEY_PATH, secureCert = CERT_PATH)
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
-        bindPort = Port(60002))
+        bindPort = Port(60542))
       pubSubTopic = "test"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
@@ -390,9 +386,9 @@ procSuite "WakuNode - Relay":
   asyncTest "Messages are relayed between nodes with multiple transports (websocket and secure Websockets)":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), bindPort = Port(60000), wsBindPort = Port(8000), wssEnabled = true, secureKey = KEY_PATH, secureCert = CERT_PATH)
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), bindPort = Port(60550), wsBindPort = Port(8000), wssEnabled = true, secureKey = KEY_PATH, secureCert = CERT_PATH)
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), bindPort = Port(60002),wsBindPort = Port(8100), wsEnabled = true )
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), bindPort = Port(60552),wsBindPort = Port(8100), wsEnabled = true )
     
     let
       pubSubTopic = "test"

--- a/tests/v2/test_wakunode_rln_relay.nim
+++ b/tests/v2/test_wakunode_rln_relay.nim
@@ -36,13 +36,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60300))
       # Relay node
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60302))
       # Subscriber
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60003))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60303))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")
@@ -122,13 +122,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60310))
       # Relay node
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60312))
       # Subscriber
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60003))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60313))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")
@@ -227,13 +227,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60320))
       # Relay node
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60322))
       # Subscriber
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60003))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60323))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")


### PR DESCRIPTION
Test cases have been failing with `[LPError] Address in use` because most of the test cases' nodes were using port 60000. 

This is a temporary patch to decouple the test cases until we support getting a random port when initializing the waku node.