### PR TITLE
feat(testlib): mark commented test cases as skipped

### DIFF
--- a/tests/v2/testlib/testutils.nim
+++ b/tests/v2/testlib/testutils.nim
@@ -1,12 +1,25 @@
-template suitex*(name: string, body: untyped) = discard
+import
+  testutils/unittests
+
 template xsuite*(name: string, body: untyped) = discard
+template suitex*(name: string, body: untyped) = discard
 
-template testx*(name: string, body: untyped) = discard
-template xtest*(name: string, body: untyped) = discard
-
-template procSuitex*(name: string, body: untyped) = discard
 template xprocSuite*(name: string, body: untyped) = discard
+template procSuitex*(name: string, body: untyped) = discard
 
-template asyncTestx*(name: string, body: untyped) = discard
-template xasyncTest*(name: string, body: untyped) = discard
-  
+
+template xtest*(name: string, body: untyped) =
+  test name:
+    skip()
+
+template testx*(name: string, body: untyped) =
+  test name:
+    skip()
+
+template xasyncTest*(name: string, body: untyped) =
+  test name:
+    skip()
+
+template asyncTestx*(name: string, body: untyped) =
+  test name:
+    skip()


### PR DESCRIPTION
Previosly, the test cases were removed from the execution, and there was no way to notice if any test case was still commented. 

Now, the test cases marked to be skipped with an ✖️ will appear as `[SKIPPED]` in the execution logs.