### PR TITLE
refactor(peer_manager): move peer_store under peer_manager module

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -22,10 +22,11 @@ import
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_peer_exchange,
   ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager/peer_store/waku_peer_storage,
+  ../../waku/v2/node/peer_manager/peer_store/migrations as peer_store_sqlite_migrations,
   ../../waku/v2/node/dnsdisc/waku_dnsdisc,
   ../../waku/v2/node/discv5/waku_discv5,
   ../../waku/v2/node/storage/migration,
-  ../../waku/v2/node/storage/peer/waku_peer_storage,
   ../../waku/v2/node/storage/message/waku_store_queue,
   ../../waku/v2/node/storage/message/sqlite_store,
   ../../waku/v2/node/storage/message/message_retention_policy,
@@ -114,7 +115,7 @@ const PeerPersistenceDbUrl = "sqlite://peers.db"
 proc setupPeerStorage(): SetupResult[Option[WakuPeerStorage]] =
   let db = ?setupDatabaseConnection(PeerPersistenceDbUrl)
   
-  ?performDbMigration(db.get(), migrationPath=MessageStoreMigrationPath)
+  ?peer_store_sqlite_migrations.migrate(db.get())
 
   let res = WakuPeerStorage.new(db.get())
   if res.isErr():

--- a/apps/wakunode2/wakunode2_setup_rest.nim
+++ b/apps/wakunode2/wakunode2_setup_rest.nim
@@ -13,7 +13,7 @@ import
 
 
 logScope:
-  topics = "wakunode.setup.rest"
+  topics = "wakunode rest"
 
 
 proc startRestServer*(node: WakuNode, address: ValidIpAddress, port: Port, conf: WakuNodeConf) = 

--- a/apps/wakunode2/wakunode2_setup_rpc.nim
+++ b/apps/wakunode2/wakunode2_setup_rpc.nim
@@ -18,7 +18,7 @@ import
   ./config
 
 logScope:
-  topics = "wakunode.setup.rpc"
+  topics = "wakunode jsonrpc"
 
 
 proc startRpcServer*(node: WakuNode, rpcIp: ValidIpAddress, rpcPort: Port, conf: WakuNodeConf)

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -17,7 +17,7 @@ import
 import
   ../../waku/common/sqlite,
   ../../waku/v2/node/peer_manager/peer_manager,
-  ../../waku/v2/node/storage/peer/waku_peer_storage,
+  ../../waku/v2/node/peer_manager/peer_store/waku_peer_storage,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/protocol/waku_store,

--- a/tests/v2/test_peer_storage.nim
+++ b/tests/v2/test_peer_storage.nim
@@ -6,7 +6,7 @@ import
 import
   ../../waku/common/sqlite,
   ../../waku/v2/node/peer_manager/peer_manager,
-  ../../waku/v2/node/storage/peer/waku_peer_storage,
+  ../../waku/v2/node/peer_manager/peer_store/waku_peer_storage,
   ../test_helpers
 
 suite "Peer Storage":

--- a/waku/v2/node/peer_manager/peer_store/migrations.nim
+++ b/waku/v2/node/peer_manager/peer_store/migrations.nim
@@ -1,0 +1,42 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+
+import
+  std/[tables, strutils, os],
+  stew/results,
+  chronicles
+import
+  ../../../../common/sqlite,
+  ../../../../common/sqlite/migrations
+
+
+logScope:
+  topics = "waku node peer_manager"
+
+
+const SchemaVersion* = 1 # increase this when there is an update in the database schema
+
+template projectRoot: string = currentSourcePath.rsplit(DirSep, 1)[0] / ".." / ".." / ".." / ".." / ".."
+const PeerStoreMigrationPath: string = projectRoot / "migrations" / "peer_store"
+
+
+proc migrate*(db: SqliteDatabase, targetVersion = SchemaVersion): DatabaseResult[void] = 
+  ## Compares the `user_version` of the sqlite database with the provided `targetVersion`, then
+  ## it runs migration scripts if the `user_version` is outdated. The `migrationScriptsDir` path
+  ## points to the directory holding the migrations scripts once the db is updated, it sets the
+  ## `user_version` to the `tragetVersion`.
+  ## 
+  ## If not `targetVersion` is provided, it defaults to `SchemaVersion`.
+  ##
+  ## NOTE: Down migration it is not currently supported
+  debug "starting peer store's sqlite database migration"
+
+  let migrationRes = migrate(db, targetVersion, migrationsScriptsDir=PeerStoreMigrationPath)
+  if migrationRes.isErr():
+    return err("failed to execute migration scripts: " & migrationRes.error)
+
+  debug "finished peer store's sqlite database migration"
+  ok()

--- a/waku/v2/node/peer_manager/peer_store/peer_storage.nim
+++ b/waku/v2/node/peer_manager/peer_store/peer_storage.nim
@@ -1,8 +1,13 @@
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
 
 import
-  stew/results,
-  ../../peer_manager/waku_peer_store
+  stew/results
+import
+  ../waku_peer_store
 
 ## This module defines a peer storage interface. Implementations of
 ## PeerStorage are used to store and retrieve peers

--- a/waku/v2/node/peer_manager/peer_store/waku_peer_storage.nim
+++ b/waku/v2/node/peer_manager/peer_store/waku_peer_storage.nim
@@ -1,4 +1,8 @@
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+  
 
 import
   std/sets, 
@@ -7,7 +11,7 @@ import
   libp2p/protobuf/minprotobuf
 import
   ../../../../common/sqlite,
-  ../../peer_manager/waku_peer_store,
+  ../waku_peer_store,
   ./peer_storage
 
 export sqlite


### PR DESCRIPTION
As part of the work done under #1293, the peer persistence database was decoupled from the message store database connection. This PR continues that work:

- [x] Moved `peer_store` module under `peer_manager` module. The code has been collocated with the peer manager code, as it is the only module depending on the peer store.
- [x] Decoupled `migrations.migrate()` procedure from the message store's.
- [x] Used a different migrations `SchemaVersion` than the message's store database. 
- [x] Updated the `wakunode2` module, the tests, and imports in general accordingly.