### PR TITLE
chore: build rln dependecies only when building v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,24 +18,47 @@ EXCLUDED_NIM_PACKAGES := vendor/nim-dnsdisc/vendor
 
 LINK_PCRE := 0
 
+
+# Get git version
+GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
+
+# Detecting the os
+ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
+ detected_OS := Windows
+else ifeq ($(strip $(shell uname)),Darwin)
+ detected_OS := macOS
+else
+ # e.g. Linux
+ detected_OS := $(strip $(shell uname))
+endif
+
+
 # we don't want an error here, so we can handle things later, in the ".DEFAULT" target
 -include $(BUILD_SYSTEM_DIR)/makefiles/variables.mk
 
 .PHONY: \
 	all \
-	deps \
-	update \
-	sim1 \
-	wakunode1 \
-	wakunode2 \
-	example1 \
-	example2 \
-	wakubridge \
 	test \
+	update \
 	clean \
+	libbacktrace \
+	deps \
+	deps2 \
+	v1 \
+	v2 \
+	test1 \
+	test2 \
+	wakunode1 \
+	example1 \
+	sim1 \
+	wakunode2 \
+	example2 \
+	sim2 \
+	wakubridge \
+	chat2 \
+	chat2bridge \
 	libwaku.so \
-	wrappers \
-	libbacktrace
+	wrappers
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.
@@ -55,11 +78,19 @@ else # "variables.mk" was included. Business as usual until the end of this file
 # default target, because it's the first one that doesn't start with '.'
 all: | v1 v2
 
-v1: | wakunode1 sim1 example1
-v2: | wakunode2 sim2 example2 chat2 wakubridge chat2bridge
+v1: | wakunode1 example1 sim1 
+v2: | wakunode2 example2 sim2 wakubridge chat2 chat2bridge
+
+# Builds and run the test suite (Waku v1 + v2)
+test: | test1 test2
+
 
 # must be included after the default target
 -include $(BUILD_SYSTEM_DIR)/makefiles/targets.mk
+
+
+# git version
+NIM_PARAMS := $(NIM_PARAMS) -d:git_version:\"$(GIT_VERSION)\"
 
 # "-d:release" implies "--stacktrace:off" and it cannot be added to config.nims
 ifeq ($(USE_LIBBACKTRACE), 0)
@@ -68,25 +99,121 @@ else
 NIM_PARAMS := $(NIM_PARAMS) -d:release
 endif
 
+
+# symlink
+waku.nims:
+	ln -s waku.nimble $@
+
+# nim-libbacktrace
+libbacktrace:
+	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
+
+
+# Common dependencies
+deps: | deps-common nat-libs waku.nims
+ifneq ($(USE_LIBBACKTRACE), 0)
+deps: | libbacktrace
+endif
+
+# Waku v2-only dependencies
+deps2: | rlnlib rlnzerokitlib
+
+
+#- deletes and recreates "waku.nims" which on Windows is a copy instead of a proper symlink
+update: | update-common
+	rm -rf waku.nims && \
+		$(MAKE) waku.nims $(HANDLE_OUTPUT)
+
+
+## Whisper targets
+
+testwhisper: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim testwhisper $(NIM_PARAMS) waku.nims
+
+
+## Waku v1 targets
+
+test1: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim test1 $(NIM_PARAMS) waku.nims
+
+wakunode1: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim wakunode1 $(NIM_PARAMS) waku.nims
+
+example1: | build
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim example1 $(NIM_PARAMS) waku.nims
+
+sim1: | build deps wakunode1
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim sim1 $(NIM_PARAMS) waku.nims
+
+
+## Waku v2 targets
+
+test2: | build deps deps2 installganache
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) waku.nims
+	# the following command (pkill -f ganache-cli) attempts to kill ganache-cli process on macos  
+	# if we do not kill the process then it would hang there and causes issue in GitHub Actions macos job (the job never finsihes)
+	(([[ $(detected_OS) = macOS ]] && \
+		pkill -f ganache-cli) || true)
+
+wakunode2: | build deps deps2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim wakunode2 $(NIM_PARAMS) waku.nims
+
+example2: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim example2 $(NIM_PARAMS) waku.nims
+
+sim2: | build deps deps2 wakunode2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim sim2 $(NIM_PARAMS) waku.nims
+
+scripts2: | build deps wakunode2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim scripts2 $(NIM_PARAMS) waku.nims
+
+wakubridge: | build deps deps2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim bridge $(NIM_PARAMS) waku.nims
+
+chat2: | build deps deps2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim chat2 $(NIM_PARAMS) waku.nims
+
+chat2bridge: | build deps deps2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim chat2bridge $(NIM_PARAMS) waku.nims
+
+## Waku v2 tooling targets
+
+wakucanary: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim wakucanary $(NIM_PARAMS) waku.nims
+
+
+## Waku docs
+
+docs: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim doc --accept --index:on --project --out:.gh-pages waku/waku.nim waku.nims
+
+
+## RLN
+
 # control rln code compilation
 ifeq ($(RLN), true)
 NIM_PARAMS := $(NIM_PARAMS) -d:rlnzerokit
 else ifeq ($(CI), true)
-NIM_PARAMS := $(NIM_PARAMS) -d:rlnzerokit 
+NIM_PARAMS := $(NIM_PARAMS) -d:rlnzerokit
 endif
 
 ifeq ($(RLNKILIC), true)
 NIM_PARAMS := $(NIM_PARAMS) -d:rln
-endif
-
-# detecting the os
-ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
- detected_OS := Windows
-else ifeq ($(strip $(shell uname)),Darwin)
- detected_OS := macOS
-else
- # e.g. Linux
- detected_OS := $(strip $(shell uname))
 endif
 
 # control compilation of rln tests that require on chain interaction
@@ -99,72 +226,6 @@ NIM_PARAMS := $(NIM_PARAMS) -d:onchain_rln
 endif
 endif
 endif
-
-# use a separate waku discv5 network with `protocol-id="d5waku"`
-NIM_PARAMS := $(NIM_PARAMS) -d:discv5_protocol_id:d5waku
-
-# enable runtime log-level filtering (see setLogLevel)
-NIM_PARAMS := $(NIM_PARAMS) -d:chronicles_runtime_filtering:on
-
-# git version for JSON RPC call
-GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
-NIM_PARAMS := $(NIM_PARAMS) -d:git_version:\"$(GIT_VERSION)\"
-
-deps: | deps-common nat-libs waku.nims rlnlib rlnzerokitlib
-ifneq ($(USE_LIBBACKTRACE), 0)
-deps: | libbacktrace
-endif
-
-#- deletes and recreates "waku.nims" which on Windows is a copy instead of a proper symlink
-update: | update-common
-	rm -rf waku.nims && \
-		$(MAKE) waku.nims $(HANDLE_OUTPUT)
-
-# a phony target, because teaching `make` how to do conditional recompilation of Nim projects is too complicated
-
-# Whisper tests
-testwhisper: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim testwhisper $(NIM_PARAMS) waku.nims
-
-# Waku v1 targets
-wakunode1: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim wakunode1 $(NIM_PARAMS) waku.nims
-
-sim1: | build deps wakunode1
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim sim1 $(NIM_PARAMS) waku.nims
-
-example1: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim example1 $(NIM_PARAMS) waku.nims
-
-test1: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim test1 $(NIM_PARAMS) waku.nims
-
-docs: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim doc --accept --index:on --project --out:.gh-pages waku/waku.nim waku.nims
-
-# Waku v2 targets
-wakunode2: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim wakunode2 $(NIM_PARAMS) waku.nims
-
-sim2: | build deps wakunode2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim sim2 $(NIM_PARAMS) waku.nims
-
-example2: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim example2 $(NIM_PARAMS) waku.nims
-
-# Waku tooling targets
-wakucanary: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim wakucanary $(NIM_PARAMS) waku.nims
 
 
 installganache:
@@ -186,7 +247,6 @@ ifeq ($(RLNKILIC), true)
 # 	cargo build --manifest-path vendor/rln/Cargo.toml
 endif
 
-
 rlnzerokitlib:
 ifeq ($(RLN), true)
 	cargo build --manifest-path vendor/zerokit/rln/Cargo.toml --release
@@ -195,40 +255,16 @@ else  ifeq ($(CI), true)
 	cargo build --manifest-path vendor/zerokit/rln/Cargo.toml --release
 endif
 
-test2: | build deps installganache
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) waku.nims
-	# the following command (pkill -f ganache-cli) attempts to kill ganache-cli process on macos  
-	# if we do not kill the process then it would hang there and causes issue in GitHub Actions macos job (the job never finsihes)
-	(([[ $(detected_OS) = macOS ]] && \
-		pkill -f ganache-cli) || true)
+# clean the rln build (forces recompile of old crates on next build)
+cleanrln:
+	cargo clean --manifest-path vendor/rln/Cargo.toml
 
-scripts2: | build deps wakunode2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim scripts2 $(NIM_PARAMS) waku.nims
+# clean the rln build (forces recompile of old crates on next build)
+cleanrlnzerokit:
+	cargo clean --manifest-path vendor/zerokit/rln/Cargo.toml
 
-chat2: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim chat2 $(NIM_PARAMS) waku.nims
 
-wakubridge: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim bridge $(NIM_PARAMS) waku.nims
-
-chat2bridge: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim chat2bridge $(NIM_PARAMS) waku.nims
-
-# Builds and run the test suite (Waku v1 + v2)
-test: | test1 test2
-
-# symlink
-waku.nims:
-	ln -s waku.nimble $@
-
-# nim-libbacktrace
-libbacktrace:
-	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
+## Container image targets
 
 # build a docker image for the fleet
 docker-image: MAKE_TARGET ?= wakunode1
@@ -252,17 +288,13 @@ endif
 	cargo clean --manifest-path vendor/rln/Cargo.toml
 	cargo clean --manifest-path vendor/zerokit/rln/Cargo.toml
 
-# clean the rln build (forces recompile of old crates on next build)
-cleanrln:
-	cargo clean --manifest-path vendor/rln/Cargo.toml
-
-# clean the rln build (forces recompile of old crates on next build)
-cleanrlnzerokit:
-	cargo clean --manifest-path vendor/zerokit/rln/Cargo.toml
 
 endif # "variables.mk" was not included
 
-libwaku.so: | build deps
+
+## Waku wrappers targets
+
+libwaku.so: | build deps deps2
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim c --app:lib --noMain --nimcache:nimcache/libwaku $(NIM_PARAMS) -o:build/$@.0 wrappers/libwaku.nim && \
 		rm -f build/$@ && \
@@ -270,7 +302,7 @@ libwaku.so: | build deps
 
 # libraries for dynamic linking of non-Nim objects
 EXTRA_LIBS_DYNAMIC := -L"$(CURDIR)/build" -lwaku -lm
-wrappers: | build deps libwaku.so
+wrappers: | build deps deps2 libwaku.so
 	echo -e $(BUILD_MSG) "build/C_wrapper_example" && \
 		 $(CC) wrappers/wrapper_example.c -Wl,-rpath,'$$ORIGIN' $(EXTRA_LIBS_DYNAMIC) -g -o build/C_wrapper_example
 	echo -e $(BUILD_MSG) "build/go_wrapper_example" && \

--- a/apps/chat2/nim.cfg
+++ b/apps/chat2/nim.cfg
@@ -1,0 +1,3 @@
+-d:chronicles_line_numbers
+-d:chronicles_runtime_filtering:on
+-d:discv5_protocol_id:d5waku

--- a/apps/chat2bridge/nim.cfg
+++ b/apps/chat2bridge/nim.cfg
@@ -1,0 +1,3 @@
+-d:chronicles_line_numbers
+-d:chronicles_runtime_filtering:on
+-d:discv5_protocol_id:d5waku

--- a/apps/wakubridge/nim.cfg
+++ b/apps/wakubridge/nim.cfg
@@ -1,0 +1,3 @@
+-d:chronicles_line_numbers
+-d:chronicles_runtime_filtering:on
+-d:discv5_protocol_id:d5waku

--- a/apps/wakunode2/nim.cfg
+++ b/apps/wakunode2/nim.cfg
@@ -1,5 +1,5 @@
 -d:chronicles_line_numbers
--d:"chronicles_runtime_filtering=on"
--d:nimDebugDlOpen
+-d:chronicles_runtime_filtering:on
+-d:discv5_protocol_id:d5waku
 # Results in empty output for some reason
 #-d:"chronicles_enabled_topics=GossipSub:TRACE,WakuRelay:TRACE"

--- a/examples/v1/nim.cfg
+++ b/examples/v1/nim.cfg
@@ -1,0 +1,2 @@
+-d:chronicles_line_numbers
+-d:chronicles_runtime_filtering:on

--- a/examples/v2/nim.cfg
+++ b/examples/v2/nim.cfg
@@ -1,0 +1,3 @@
+-d:chronicles_line_numbers
+-d:chronicles_runtime_filtering:on
+-d:discv5_protocol_id:d5waku

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,0 +1,2 @@
+-d:chronicles_line_numbers
+-d:discv5_protocol_id:d5waku

--- a/tools/wakucanary/nim.cfg
+++ b/tools/wakucanary/nim.cfg
@@ -1,0 +1,3 @@
+-d:chronicles_line_numbers
+-d:chronicles_runtime_filtering:on
+-d:discv5_protocol_id:d5waku


### PR DESCRIPTION
This is a gardening 🌳 and CI optimization PR:

- [x] Tidy up the `Makefile`
- [x] Split v2 dependencies from `deps` target into `deps2` target
- [x] Build v2 dependencies only when building waku v2 code
- [x] Add a per binary `nim.cfg` for static nim defines and flags

This PR resolves #1313

----

There is some work pending to decouple the `NIM_PARAMS` as @s1fr0 pointed out in #1313, but this work should be taken in a separate piece for the sake of simplicity.