### PR TITLE
chore: rename protocols rpc_codec procs from init to decode

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -68,7 +68,7 @@ type Chat = ref object
 
 type
   PrivateKey* = crypto.PrivateKey
-  Topic* = waku_node.PubsubTopic
+  Topic* = waku_message.PubsubTopic
 
 #####################
 ## chat2 protobufs ##
@@ -514,7 +514,7 @@ proc processInput(rfd: AsyncFD) {.async.} =
     proc handler(topic: Topic, data: seq[byte]) {.async, gcsafe.} =
       trace "Hit subscribe handler", topic
 
-      let decoded = WakuMessage.init(data)
+      let decoded = WakuMessage.decode(data)
       
       if decoded.isOk():
         if decoded.get().contentTopic == chat.contentTopic:

--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -196,7 +196,7 @@ proc start*(cmb: Chat2MatterBridge) {.async.} =
   # Bridging
   # Handle messages on Waku v2 and bridge to Matterbridge
   proc relayHandler(pubsubTopic: string, data: seq[byte]) {.async, gcsafe, raises: [Defect].} =
-    let msg = WakuMessage.init(data)
+    let msg = WakuMessage.decode(data)
     if msg.isOk():
       trace "Bridging message from Chat2 to Matterbridge", msg=msg[]
       cmb.toMatterbridge(msg[])

--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -32,7 +32,7 @@ proc runBackground() {.async.} =
   # Subscribe to a topic
   let topic = PubsubTopic("foobar")
   proc handler(topic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
-    let message = WakuMessage.init(data).value
+    let message = WakuMessage.decode(data).value
     let payload = cast[string](message.payload)
     info "Hit subscribe handler", topic=topic, payload=payload, contentTopic=message.contentTopic
   node.subscribe(topic, handler)

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -70,7 +70,7 @@ proc setupAndSubscribe() {.async.} =
     let contentTopic = ContentTopic("/examples/1/pubsub-example/proto")
 
     proc handler(pubsubTopic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
-      let message = WakuMessage.init(data).value
+      let message = WakuMessage.decode(data).value
       let payloadStr = string.fromBytes(message.payload)
       if message.contentTopic == contentTopic:
         notice "message received", payload=payloadStr,

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -128,7 +128,7 @@ procSuite "WakuBridge":
     var completionFut = newFuture[bool]()
 
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =      
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       
       if msg.isOk() and msg.value().version == 1:
         check:

--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -101,7 +101,7 @@ procSuite "Waku Discovery v5":
     # Let's see if we can deliver a message end-to-end
     # var completionFut = newFuture[bool]()
     # proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-    #   let msg = WakuMessage.init(data)
+    #   let msg = WakuMessage.decode(data)
     #   if msg.isOk():
     #     let val = msg.value()
     #     check:

--- a/tests/v2/test_waku_noise.nim
+++ b/tests/v2/test_waku_noise.nim
@@ -172,7 +172,7 @@ procSuite "Waku Noise":
     let pb = msg.get().encode()
 
     # We decode the WakuMessage from the ProtoBuffer
-    let msgFromPb = WakuMessage.init(pb.buffer)
+    let msgFromPb = WakuMessage.decode(pb.buffer)
     
     check:
       msgFromPb.isOk()

--- a/tests/v2/test_waku_noise_sessions.nim
+++ b/tests/v2/test_waku_noise_sessions.nim
@@ -128,7 +128,7 @@ procSuite "Waku Noise Sessions":
     pb = wakuMsg.get().encode()
 
     # We decode the WakuMessage from the ProtoBuffer
-    msgFromPb = WakuMessage.init(pb.buffer)
+    msgFromPb = WakuMessage.decode(pb.buffer)
     
     check:
       msgFromPb.isOk()
@@ -185,7 +185,7 @@ procSuite "Waku Noise Sessions":
     pb = wakuMsg.get().encode()
 
     # We decode the WakuMessage from the ProtoBuffer
-    msgFromPb = WakuMessage.init(pb.buffer)
+    msgFromPb = WakuMessage.decode(pb.buffer)
     
     check:
       msgFromPb.isOk()
@@ -238,7 +238,7 @@ procSuite "Waku Noise Sessions":
     pb = wakuMsg.get().encode()
 
     # We decode the WakuMessage from the ProtoBuffer
-    msgFromPb = WakuMessage.init(pb.buffer)
+    msgFromPb = WakuMessage.decode(pb.buffer)
     
     check:
       msgFromPb.isOk()

--- a/tests/v2/test_waku_payload.nim
+++ b/tests/v2/test_waku_payload.nim
@@ -21,7 +21,7 @@ procSuite "Waku Payload":
       pb =  msg.encode()
 
     # Decoding
-    let msgDecoded = WakuMessage.init(pb.buffer)
+    let msgDecoded = WakuMessage.decode(pb.buffer)
     check msgDecoded.isOk()
 
     let
@@ -47,7 +47,7 @@ procSuite "Waku Payload":
       pb =  msg.encode()
 
     # Decoding
-    let msgDecoded = WakuMessage.init(pb.buffer)
+    let msgDecoded = WakuMessage.decode(pb.buffer)
     check msgDecoded.isOk()
 
     let
@@ -73,7 +73,7 @@ procSuite "Waku Payload":
       pb =  msg.encode()
 
     # Decoding
-    let msgDecoded = WakuMessage.init(pb.buffer)
+    let msgDecoded = WakuMessage.decode(pb.buffer)
     check msgDecoded.isOk()
 
     let
@@ -101,7 +101,7 @@ procSuite "Waku Payload":
       pb =  msg.encode()
 
     # Decoding
-    let msgDecoded = WakuMessage.init(pb.buffer)
+    let msgDecoded = WakuMessage.decode(pb.buffer)
     check msgDecoded.isOk()
 
     let
@@ -123,7 +123,7 @@ procSuite "Waku Payload":
       
     ## When
     let pb =  msg.encode()
-    let msgDecoded = WakuMessage.init(pb.buffer)
+    let msgDecoded = WakuMessage.decode(pb.buffer)
     
     ## Then
     check:
@@ -144,7 +144,7 @@ procSuite "Waku Payload":
     
     ## When
     let pb =  msg.encode()
-    let msgDecoded = WakuMessage.init(pb.buffer)
+    let msgDecoded = WakuMessage.decode(pb.buffer)
 
     ## Then
     check:

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -45,7 +45,7 @@ procSuite "Waku Peer Exchange":
     ## When
     let
       rpcBuffer: seq[byte] = rpc.encode().buffer
-      res = PeerExchangeRpc.init(rpcBuffer)
+      res = PeerExchangeRpc.decode(rpcBuffer)
 
     ## Then
     check:

--- a/tests/v2/test_waku_store_rpc_codec.nim
+++ b/tests/v2/test_waku_store_rpc_codec.nim
@@ -18,7 +18,7 @@ procSuite "Waku Store - RPC codec":
 
     ## When
     let encodedIndex = index.encode()
-    let decodedIndexRes = PagingIndex.init(encodedIndex.buffer)
+    let decodedIndexRes = PagingIndex.decode(encodedIndex.buffer)
 
     ## Then
     check:
@@ -34,7 +34,7 @@ procSuite "Waku Store - RPC codec":
     let emptyIndex = PagingIndex()
     
     let encodedIndex = emptyIndex.encode()
-    let decodedIndexRes = PagingIndex.init(encodedIndex.buffer)
+    let decodedIndexRes = PagingIndex.decode(encodedIndex.buffer)
 
     ## Then
     check:
@@ -53,7 +53,7 @@ procSuite "Waku Store - RPC codec":
       
     ## When
     let pb = pagingInfo.encode()
-    let decodedPagingInfo = PagingInfo.init(pb.buffer)
+    let decodedPagingInfo = PagingInfo.decode(pb.buffer)
 
     ## Then
     check:
@@ -69,8 +69,8 @@ procSuite "Waku Store - RPC codec":
     let emptyPagingInfo = PagingInfo()
       
     ## When
-    let epb = emptyPagingInfo.encode()
-    let decodedEmptyPagingInfo = PagingInfo.init(epb.buffer)
+    let pb = emptyPagingInfo.encode()
+    let decodedEmptyPagingInfo = PagingInfo.decode(pb.buffer)
 
     ## Then
     check:
@@ -89,7 +89,7 @@ procSuite "Waku Store - RPC codec":
     
     ## When
     let pb = query.encode()
-    let decodedQuery = HistoryQuery.init(pb.buffer)
+    let decodedQuery = HistoryQuery.decode(pb.buffer)
 
     ## Then
     check:
@@ -104,8 +104,8 @@ procSuite "Waku Store - RPC codec":
     let emptyQuery = HistoryQuery()
 
     ## When
-    let epb = emptyQuery.encode()
-    let decodedEmptyQuery = HistoryQuery.init(epb.buffer)
+    let pb = emptyQuery.encode()
+    let decodedEmptyQuery = HistoryQuery.decode(pb.buffer)
 
     ## Then
     check:
@@ -125,7 +125,7 @@ procSuite "Waku Store - RPC codec":
     
     ## When
     let pb = res.encode()
-    let decodedRes = HistoryResponse.init(pb.buffer)
+    let decodedRes = HistoryResponse.decode(pb.buffer)
 
     ## Then
     check:
@@ -140,8 +140,8 @@ procSuite "Waku Store - RPC codec":
     let emptyRes = HistoryResponse()
     
     ## When
-    let epb = emptyRes.encode()
-    let decodedEmptyRes = HistoryResponse.init(epb.buffer)
+    let pb = emptyRes.encode()
+    let decodedEmptyRes = HistoryResponse.decode(pb.buffer)
 
     ## Then
     check:

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -58,7 +58,7 @@ procSuite "WakuNode":
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let val = msg.value()
         check:

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -44,7 +44,7 @@ procSuite "WakuNode - Lightpush":
 
     var completionFutRelay = newFuture[bool]()
     proc relayHandler(pubsubTopic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data).get()
+      let msg = WakuMessage.decode(data).get()
       check:
         pubsubTopic == DefaultPubsubTopic
         msg == message

--- a/tests/v2/test_wakunode_relay.nim
+++ b/tests/v2/test_wakunode_relay.nim
@@ -89,7 +89,7 @@ procSuite "WakuNode - Relay":
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let val = msg.value()
         check:
@@ -158,7 +158,7 @@ procSuite "WakuNode - Relay":
       ## the validator that only allows messages with contentTopic1 to be relayed
       check:
         topic == pubSubTopic
-      let msg = WakuMessage.init(message.data)
+      let msg = WakuMessage.decode(message.data)
       if msg.isOk():
         # only relay messages with contentTopic1
         if msg.value().contentTopic  == contentTopic1:
@@ -175,7 +175,7 @@ procSuite "WakuNode - Relay":
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
       debug "relayed pubsub topic:", topic
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let val = msg.value()
         check:
@@ -228,7 +228,7 @@ procSuite "WakuNode - Relay":
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let val = msg.value()
         check:
@@ -272,7 +272,7 @@ procSuite "WakuNode - Relay":
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let val = msg.value()
         check:
@@ -320,7 +320,7 @@ procSuite "WakuNode - Relay":
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let val = msg.value()
         check:
@@ -363,7 +363,7 @@ procSuite "WakuNode - Relay":
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let val = msg.value()
         check:
@@ -406,7 +406,7 @@ procSuite "WakuNode - Relay":
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let val = msg.value()
         check:

--- a/tests/v2/test_wakunode_rln_relay.nim
+++ b/tests/v2/test_wakunode_rln_relay.nim
@@ -107,7 +107,7 @@ procSuite "WakuNode - RLN relay":
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         debug "The received topic:", topic
         if topic == rlnRelayPubSubTopic:
@@ -212,7 +212,7 @@ procSuite "WakuNode - RLN relay":
     # define a custom relay handler
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         debug "The received topic:", topic
         if topic == rlnRelayPubSubTopic:
@@ -361,7 +361,7 @@ procSuite "WakuNode - RLN relay":
     var completionFut3 = newFuture[bool]()
     var completionFut4 = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
+      let msg = WakuMessage.decode(data)
       if msg.isOk():
         let wm = msg.value()
         debug "The received topic:", topic

--- a/waku/v2/node/jsonrpc/relay_api.nim
+++ b/waku/v2/node/jsonrpc/relay_api.nim
@@ -25,7 +25,7 @@ proc installRelayApiHandlers*(node: WakuNode, rpcsrv: RpcServer, topicCache: Top
   
   proc topicHandler(topic: string, data: seq[byte]) {.async, raises: [Defect].} =
     trace "Topic handler triggered", topic=topic
-    let msg = WakuMessage.init(data)
+    let msg = WakuMessage.decode(data)
     if msg.isOk():
       # Add message to current cache
       trace "WakuMessage received", msg=msg, topic=topic

--- a/waku/v2/node/rest/relay/topic_cache.nim
+++ b/waku/v2/node/rest/relay/topic_cache.nim
@@ -37,7 +37,7 @@ proc messageHandler*(cache: TopicCache): TopicCacheMessageHandler =
     trace "Topic handler triggered", topic=topic
 
     # Add message to current cache
-    let msg = WakuMessage.init(data)
+    let msg = WakuMessage.decode(data)
     if msg.isErr():
       debug "WakuMessage received but failed to decode", msg=msg, topic=topic
       # TODO: handle message decode failure

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -62,9 +62,6 @@ const git_version* {.strdefine.} = "n/a"
 # Default clientId
 const clientId* = "Nimbus Waku v2 node"
 
-# TODO: Unify pubusub topic type and default value
-type PubsubTopic* = string
-
 const defaultTopic*: PubsubTopic = "/waku/2/default-waku/proto"
 
 # Default Waku Filter Timeout
@@ -270,7 +267,7 @@ proc subscribe(node: WakuNode, topic: PubsubTopic, handler: Option[TopicHandler]
     # A default handler should be registered for all topics
     trace "Hit default handler", topic=topic, data=data
 
-    let msg = WakuMessage.init(data)
+    let msg = WakuMessage.decode(data)
     if msg.isErr():
       # TODO: Add metric to track waku message decode errors
       return

--- a/waku/v2/protocol/waku_filter/client.nim
+++ b/waku/v2/protocol/waku_filter/client.nim
@@ -90,7 +90,7 @@ proc initProtocolHandler(wf: WakuFilterClient) =
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
     let buffer = await conn.readLp(MaxRpcSize.int)
 
-    let decodeReqRes = FilterRPC.init(buffer)
+    let decodeReqRes = FilterRPC.decode(buffer)
     if decodeReqRes.isErr():
       waku_filter_errors.inc(labelValues = [decodeRpcFailure])
       return

--- a/waku/v2/protocol/waku_filter/protocol.nim
+++ b/waku/v2/protocol/waku_filter/protocol.nim
@@ -90,7 +90,7 @@ proc initProtocolHandler(wf: WakuFilter) =
   proc handler(conn: Connection, proto: string) {.async, gcsafe, closure.} =
     let buffer = await conn.readLp(MaxRpcSize.int)
 
-    let decodeRpcRes = FilterRPC.init(buffer)
+    let decodeRpcRes = FilterRPC.decode(buffer)
     if decodeRpcRes.isErr():
       waku_filter_errors.inc(labelValues = [decodeRpcFailure])
       return

--- a/waku/v2/protocol/waku_lightpush/client.nim
+++ b/waku/v2/protocol/waku_lightpush/client.nim
@@ -46,7 +46,7 @@ proc sendPushRequest(wl: WakuLightPushClient, req: PushRequest, peer: PeerId|Rem
   await connection.writeLP(rpc.encode().buffer)
 
   var buffer = await connection.readLp(MaxRpcSize.int)
-  let decodeRespRes = PushRPC.init(buffer)
+  let decodeRespRes = PushRPC.decode(buffer)
   if decodeRespRes.isErr():
     error "failed to decode response"
     waku_lightpush_errors.inc(labelValues = [decodeRpcFailure])

--- a/waku/v2/protocol/waku_lightpush/protocol.nim
+++ b/waku/v2/protocol/waku_lightpush/protocol.nim
@@ -38,7 +38,7 @@ type
 proc initProtocolHandler*(wl: WakuLightPush) =
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
     let buffer = await conn.readLp(MaxRpcSize.int)
-    let reqDecodeRes = PushRPC.init(buffer)
+    let reqDecodeRes = PushRPC.decode(buffer)
     if reqDecodeRes.isErr():
       error "failed to decode rpc"
       waku_lightpush_errors.inc(labelValues = [decodeRpcFailure])

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -5,26 +5,29 @@
 ##
 ## For payload content and encryption, see waku/v2/node/waku_payload.nim
 
-
 when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}
 
+
 import
   libp2p/protobuf/minprotobuf,
-  libp2p/varint,
+  libp2p/varint
+import
   ../utils/protobuf,
   ../utils/time,
-  waku_rln_relay/waku_rln_relay_types
+  ./waku_rln_relay/waku_rln_relay_types
 
-const
-  MaxWakuMessageSize* = 1024 * 1024 # In bytes. Corresponds to PubSub default
+
+const MaxWakuMessageSize* = 1024 * 1024 # In bytes. Corresponds to PubSub default
 
 type
+  PubsubTopic* = string
   ContentTopic* = string
 
-  WakuMessage* = object
+
+type WakuMessage* = object
     payload*: seq[byte]
     contentTopic*: ContentTopic
     version*: uint32
@@ -38,45 +41,42 @@ type
     # be stored. bools and uints are 
     # equivalent in serialization of the protobuf
     ephemeral*: bool
-    
-   
 
-# Encoding and decoding -------------------------------------------------------
-proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
+
+## Encoding and decoding
+
+proc encode*(message: WakuMessage): ProtoBuffer =
+  var buf = initProtoBuffer()
+
+  buf.write3(1, message.payload)
+  buf.write3(2, message.contentTopic)
+  buf.write3(3, message.version)
+  buf.write3(10, zint64(message.timestamp))
+  buf.write3(21, message.proof.encode())
+  buf.write3(31, uint64(message.ephemeral))
+  buf.finish3()
+
+  buf
+
+proc decode*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
   var msg = WakuMessage(ephemeral: false)
   let pb = initProtoBuffer(buffer)
 
-  discard ? pb.getField(1, msg.payload)
-  discard ? pb.getField(2, msg.contentTopic)
-  discard ? pb.getField(3, msg.version)
+  discard ?pb.getField(1, msg.payload)
+  discard ?pb.getField(2, msg.contentTopic)
+  discard ?pb.getField(3, msg.version)
 
   var timestamp: zint64
-  discard ? pb.getField(10, timestamp)
+  discard ?pb.getField(10, timestamp)
   msg.timestamp = Timestamp(timestamp)
 
   # XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec
   var proofBytes: seq[byte]
-  discard ? pb.getField(21, proofBytes)
-  msg.proof = ? RateLimitProof.init(proofBytes)
+  discard ?pb.getField(21, proofBytes)
+  msg.proof = ?RateLimitProof.init(proofBytes)
 
-  # Behaviour of ephemeral with storeTTL to be defined,
-  # If a message is marked ephemeral, it should not have a storeTTL.
-  # If a message is not marked ephemeral, it should have a storeTTL.
-  # How would we handle messages that should be stored permanently?
   var ephemeral: uint
-  if ? pb.getField(31, ephemeral):
+  if ?pb.getField(31, ephemeral):
     msg.ephemeral = bool(ephemeral)
 
   ok(msg)
-
-proc encode*(message: WakuMessage): ProtoBuffer =
-  result = initProtoBuffer()
-
-  result.write3(1, message.payload)
-  result.write3(2, message.contentTopic)
-  result.write3(3, message.version)
-  result.write3(10, zint64(message.timestamp))
-  result.write3(21, message.proof.encode())
-  result.write3(31, uint64(message.ephemeral))
-  result.finish3()
-

--- a/waku/v2/protocol/waku_peer_exchange/protocol.nim
+++ b/waku/v2/protocol/waku_peer_exchange/protocol.nim
@@ -153,7 +153,7 @@ proc initProtocolHandler(wpx: WakuPeerExchange) =
   proc handler(conn: Connection, proto: string) {.async, gcsafe, closure.} =
     let buff = await conn.readLp(MaxRpcSize.int)
 
-    let res = PeerExchangeRpc.init(buff)
+    let res = PeerExchangeRpc.decode(buff)
     if res.isErr():
       waku_px_errors.inc(labelValues = [decodeRpcFailure])
       return

--- a/waku/v2/protocol/waku_peer_exchange/rpc_codec.nim
+++ b/waku/v2/protocol/waku_peer_exchange/rpc_codec.nim
@@ -3,6 +3,7 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
+
 import
   libp2p/protobuf/minprotobuf,
   libp2p/varint
@@ -10,85 +11,86 @@ import
   ../../utils/protobuf,
   ./rpc
 
+
 proc encode*(rpc: PeerExchangeRequest): ProtoBuffer =
-  var output = initProtoBuffer()
+  var pb = initProtoBuffer()
 
-  output.write3(1, rpc.numPeers)
-  output.finish3()
+  pb.write3(1, rpc.numPeers)
+  pb.finish3()
 
-  return output
+  pb
 
-proc init*(T: type PeerExchangeRequest, buffer: seq[byte]): ProtoResult[T] =
+proc decode*(T: type PeerExchangeRequest, buffer: seq[byte]): ProtoResult[T] =
   let pb = initProtoBuffer(buffer)
-
   var rpc = PeerExchangeRequest(numPeers: 0)
 
   var numPeers: uint64
   if ?pb.getField(1, numPeers):
     rpc.numPeers = numPeers
 
-  return ok(rpc)
+  ok(rpc)
+
 
 proc encode*(rpc: PeerExchangePeerInfo): ProtoBuffer =
-  var output = initProtoBuffer()
+  var pb = initProtoBuffer()
 
-  output.write3(1, rpc.enr)
-  output.finish3()
+  pb.write3(1, rpc.enr)
+  pb.finish3()
 
-  return output
+  pb
 
-proc init*(T: type PeerExchangePeerInfo, buffer: seq[byte]): ProtoResult[T] =
+proc decode*(T: type PeerExchangePeerInfo, buffer: seq[byte]): ProtoResult[T] =
   let pb = initProtoBuffer(buffer)
-
   var rpc = PeerExchangePeerInfo(enr: @[])
 
   var peerInfoBuffer: seq[byte]
   if ?pb.getField(1, peerInfoBuffer):
-      rpc.enr = peerInfoBuffer
+    rpc.enr = peerInfoBuffer
 
-  return ok(rpc)
+  ok(rpc)
+
 
 proc encode*(rpc: PeerExchangeResponse): ProtoBuffer =
-  var output = initProtoBuffer()
+  var pb = initProtoBuffer()
 
   for pi in rpc.peerInfos:
-    output.write3(1, pi.encode())
-  output.finish3()
+    pb.write3(1, pi.encode())
 
-  return output
+  pb.finish3()
 
-proc init*(T: type PeerExchangeResponse, buffer: seq[byte]): ProtoResult[T] =
+  pb
+
+proc decode*(T: type PeerExchangeResponse, buffer: seq[byte]): ProtoResult[T] =
   let pb = initProtoBuffer(buffer)
-
   var rpc = PeerExchangeResponse(peerInfos: @[])
 
   var peerInfoBuffers: seq[seq[byte]]
   if ?pb.getRepeatedField(1, peerInfoBuffers):
     for pib in peerInfoBuffers:
-      rpc.peerInfos.add(?PeerExchangePeerInfo.init(pib))
+      rpc.peerInfos.add(?PeerExchangePeerInfo.decode(pib))
 
-  return ok(rpc)
+  ok(rpc)
+
 
 proc encode*(rpc: PeerExchangeRpc): ProtoBuffer =
-  var output = initProtoBuffer()
-  output.write3(1, rpc.request.encode())
-  output.write3(2, rpc.response.encode())
-  output.finish3()
+  var pb = initProtoBuffer()
 
-  return output
+  pb.write3(1, rpc.request.encode())
+  pb.write3(2, rpc.response.encode())
+  pb.finish3()
 
-proc init*(T: type PeerExchangeRpc, buffer: seq[byte]): ProtoResult[T] =
+  pb
+
+proc decode*(T: type PeerExchangeRpc, buffer: seq[byte]): ProtoResult[T] =
   let pb = initProtoBuffer(buffer)
-
   var rpc = PeerExchangeRpc()
 
   var requestBuffer: seq[byte]
   discard ?pb.getField(1, requestBuffer)
-  rpc.request = ?PeerExchangeRequest.init(requestBuffer)
+  rpc.request = ?PeerExchangeRequest.decode(requestBuffer)
 
   var responseBuffer: seq[byte]
   discard ?pb.getField(2, responseBuffer)
-  rpc.response = ?PeerExchangeResponse.init(responseBuffer)
+  rpc.response = ?PeerExchangeResponse.decode(responseBuffer)
 
-  return ok(rpc)
-
+  ok(rpc)

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1062,7 +1062,7 @@ proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: string, contentTopic: Co
   ## the message validation logic is according to https://rfc.vac.dev/spec/17/
   proc validator(topic: string, message: messages.Message): Future[pubsub.ValidationResult] {.async.} =
     trace "rln-relay topic validator is called"
-    let msg = WakuMessage.init(message.data) 
+    let msg = WakuMessage.decode(message.data) 
     if msg.isOk():
       let 
         wakumessage = msg.value()

--- a/waku/v2/protocol/waku_store/client.nim
+++ b/waku/v2/protocol/waku_store/client.nim
@@ -52,7 +52,7 @@ proc query*(w: WakuStoreClient, req: HistoryQuery, peer: RemotePeerInfo): Future
   await connection.writeLP(rpc.encode().buffer)
 
   var message = await connection.readLp(MaxRpcSize.int)
-  let response = HistoryRPC.init(message)
+  let response = HistoryRPC.decode(message)
 
   if response.isErr():
     error "failed to decode response"

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -171,7 +171,7 @@ proc initProtocolHandler*(ws: WakuStore) =
   proc handler(conn: Connection, proto: string) {.async.} =
     let buf = await conn.readLp(MaxRpcSize.int)
 
-    let resReq = HistoryRPC.init(buf)
+    let resReq = HistoryRPC.decode(buf)
     if resReq.isErr():
       error "failed to decode rpc", peerId=conn.peerId
       waku_store_errors.inc(labelValues = [decodeRpcFailure])


### PR DESCRIPTION
This is another gardening PR 🌳 

- [x] Rename RPC types codec methods from init to decode
- [x] Move `PubsubTopic` type from `waku_node` module to `waku_message` module
- [x] Update tests accordingly