### PR TITLE
fix(rln-relay): remove dependency on applications' configuration

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -542,7 +542,21 @@ proc processInput(rfd: AsyncFD) {.async.} =
           echo "You are registered to the rln membership contract, find details of your registration transaction in https://goerli.etherscan.io/tx/0x", txHash
         
         echo "rln-relay preparation is in progress..."
-        let res = await node.mountRlnRelay(conf = conf, spamHandler = some(spamHandler), registrationHandler = some(registrationHandler))
+        
+        let rlnConf = WakuRlnConfig(
+          rlnRelayDynamic: conf.rlnRelayDynamic,
+          rlnRelayPubsubTopic: conf.rlnRelayPubsubTopic,
+          rlnRelayContentTopic: conf.rlnRelayContentTopic,
+          rlnRelayMembershipIndex: conf.rlnRelayMembershipIndex,
+          rlnRelayEthContractAddress: conf.rlnRelayEthContractAddress,
+          rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress,
+          rlnRelayEthAccountPrivateKey: conf.rlnRelayEthAccountPrivateKey,
+          rlnRelayEthAccountAddress: conf.rlnRelayEthAccountAddress,
+          rlnRelayCredPath: conf.rlnRelayCredPath,
+          rlnRelayCredentialsPassword: conf.rlnRelayCredentialsPassword
+        )
+
+        let res = await node.mountRlnRelay(conf=rlnConf, spamHandler = some(spamHandler), registrationHandler = some(registrationHandler))
         if res.isErr():
           echo "failed to mount rln-relay: " & res.error()
         else:

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -358,8 +358,22 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
   
   when defined(rln) or defined(rlnzerokit): 
     if conf.rlnRelay:
+      
+      let rlnConf = WakuRlnConfig(
+        rlnRelayDynamic: conf.rlnRelayDynamic,
+        rlnRelayPubsubTopic: conf.rlnRelayPubsubTopic,
+        rlnRelayContentTopic: conf.rlnRelayContentTopic,
+        rlnRelayMembershipIndex: conf.rlnRelayMembershipIndex,
+        rlnRelayEthContractAddress: conf.rlnRelayEthContractAddress,
+        rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress,
+        rlnRelayEthAccountPrivateKey: conf.rlnRelayEthAccountPrivateKey,
+        rlnRelayEthAccountAddress: conf.rlnRelayEthAccountAddress,
+        rlnRelayCredPath: conf.rlnRelayCredPath,
+        rlnRelayCredentialsPassword: conf.rlnRelayCredentialsPassword
+      )
+
       try: 
-        let res = await node.mountRlnRelay(conf)
+        let res = await node.mountRlnRelay(rlnConf)
         if res.isErr():
           return err("failed to mount waku RLN relay protocol: " & res.error)
       except:

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -20,9 +20,7 @@ import
   waku_rln_relay_metrics,
   ../../utils/time,
   ../../utils/keyfile,
-  ../../node/waku_node, 
-  ../../../../../apps/wakunode2/config,  ## TODO: Decouple the protocol code from the app configuration
-  ../../../../../apps/chat2/config_chat2,  ## TODO: Decouple the protocol code from the app configuration
+  ../../node/waku_node,
   ../waku_message
 
 logScope:
@@ -1284,8 +1282,21 @@ proc readRlnCredentials*(path: string,
       return err("Error while loading keyfile for RLN credentials at " & path)
 
 
+type WakuRlnConfig* = object
+    rlnRelayDynamic*: bool
+    rlnRelayPubsubTopic*: PubsubTopic
+    rlnRelayContentTopic*: ContentTopic
+    rlnRelayMembershipIndex*: uint
+    rlnRelayEthContractAddress*: string
+    rlnRelayEthClientAddress*: string
+    rlnRelayEthAccountPrivateKey*: string
+    rlnRelayEthAccountAddress*: string
+    rlnRelayCredPath*: string
+    rlnRelayCredentialsPassword*: string
+
+
 proc mount(node: WakuNode,
-           conf: WakuNodeConf|Chat2Conf,
+           conf: WakuRlnConfig,
            spamHandler: Option[SpamHandler] = none(SpamHandler),
            registrationHandler: Option[RegistrationHandler] = none(RegistrationHandler)
           ): Future[RlnRelayResult[void]] {.async.} =
@@ -1431,7 +1442,7 @@ proc mount(node: WakuNode,
 
 
 proc mountRlnRelay*(node: WakuNode,
-                    conf: WakuNodeConf|Chat2Conf,
+                    conf: WakuRlnConfig,
                     spamHandler: Option[SpamHandler] = none(SpamHandler),
                     registrationHandler: Option[RegistrationHandler] = none(RegistrationHandler)
                    ): Future[RlnRelayResult[void]] {.async.} =


### PR DESCRIPTION
This PR resolves #1222, the issue tracking the "imports rule violation". Previously, the code did not respect the [coding guide import rules](https://hackmd.io/5oIVOuQcSM2WKrnDLUPcpg#Importsexports). It imported an application module from a library (protocol, in this case) module.

- [x] Added a custom RLN config type
- [x] Fill the RLN config object fields form `chat2` and `wakunode2` config objects

I expect this PR to be very easy to review and merge. I have made some surgical changes trying to fix the dependency issue and reduce the impact in the PR that @staheri14 is working on to the maximum.