### PR TITLE
refactor: continue pubsub/content types started in #1352

### DIFF
--- a/tests/v2/test_message_cache.nim
+++ b/tests/v2/test_message_cache.nim
@@ -10,16 +10,12 @@ import
   ./testlib/common
 
 
-
-type PubsubTopicString = string
-
-type TestMessageCache = MessageCache[(PubsubTopicString, ContentTopic)]
-
+type TestMessageCache = MessageCache[(PubsubTopic, ContentTopic)]
 
 suite "MessageCache":
   test "subscribe to topic": 
     ## Given
-    let testTopic = ("test-pubsub-topic", ContentTopic("test-content-topic"))
+    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let cache = TestMessageCache.init()
 
     ## When
@@ -32,7 +28,7 @@ suite "MessageCache":
 
   test "unsubscribe from topic": 
     ## Given
-    let testTopic = ("test-pubsub-topic", ContentTopic("test-content-topic"))
+    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let cache = TestMessageCache.init()
 
     # Init cache content
@@ -48,7 +44,7 @@ suite "MessageCache":
 
   test "get messages of a subscribed topic":
     ## Given
-    let testTopic = ("test-pubsub-topic", ContentTopic("test-content-topic"))
+    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessage = fakeWakuMessage()
     let cache = TestMessageCache.init() 
 
@@ -67,7 +63,7 @@ suite "MessageCache":
 
   test "get messages with clean flag shoud clear the messages cache":
     ## Given
-    let testTopic = ("test-pubsub-topic", ContentTopic("test-content-topic"))
+    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessage = fakeWakuMessage()
     let cache = TestMessageCache.init() 
 
@@ -89,7 +85,7 @@ suite "MessageCache":
 
   test "get messages of a non-subscribed topic":
     ## Given
-    let testTopic = ("test-pubsub-topic", ContentTopic("test-content-topic"))
+    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let cache = TestMessageCache.init()
 
     ## When
@@ -103,7 +99,7 @@ suite "MessageCache":
 
   test "add messages to subscribed topic":
     ## Given
-    let testTopic = ("test-pubsub-topic", ContentTopic("test-content-topic"))
+    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessage = fakeWakuMessage()
     let cache = TestMessageCache.init()
 
@@ -120,7 +116,7 @@ suite "MessageCache":
 
   test "add messages to non-subscribed topic":
     ## Given
-    let testTopic = ("test-pubsub-topic", ContentTopic("test-content-topic"))
+    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessage = fakeWakuMessage()
     let cache = TestMessageCache.init()
 
@@ -136,7 +132,7 @@ suite "MessageCache":
   
   test "add messages beyond the capacity":
     ## Given
-    let testTopic = ("test-pubsub-topic", ContentTopic("test-content-topic"))
+    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessages = @[
       fakeWakuMessage(toBytes("MSG-1")),
       fakeWakuMessage(toBytes("MSG-2")),

--- a/tests/v2/test_rest_relay_api.nim
+++ b/tests/v2/test_rest_relay_api.nim
@@ -45,9 +45,9 @@ suite "REST API - Relay":
     restServer.start()
 
     let pubSubTopics = @[
-      PubSubTopicString("pubsub-topic-1"),
-      PubSubTopicString("pubsub-topic-2"),
-      PubSubTopicString("pubsub-topic-3")
+      PubSubTopic("pubsub-topic-1"),
+      PubSubTopic("pubsub-topic-2"),
+      PubSubTopic("pubsub-topic-3")
     ]
 
     # When
@@ -94,10 +94,10 @@ suite "REST API - Relay":
     restServer.start()
 
     let pubSubTopics = @[
-      PubSubTopicString("pubsub-topic-1"), 
-      PubSubTopicString("pubsub-topic-2"),
-      PubSubTopicString("pubsub-topic-3"),
-      PubSubTopicString("pubsub-topic-y")
+      PubSubTopic("pubsub-topic-1"), 
+      PubSubTopic("pubsub-topic-2"),
+      PubSubTopic("pubsub-topic-3"),
+      PubSubTopic("pubsub-topic-y")
     ]
 
     # When
@@ -190,7 +190,6 @@ suite "REST API - Relay":
     restServer.start()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
-    const defaultContentTopic = ContentTopic("/waku/2/default-content/proto")
     
     # At this stage the node is only subscribed to the default topic
     require(PubSub(node.wakuRelay).topics.len == 1)
@@ -198,15 +197,15 @@ suite "REST API - Relay":
 
     # When
     let newTopics = @[
-      PubSubTopicString("pubsub-topic-1"),
-      PubSubTopicString("pubsub-topic-2"),
-      PubSubTopicString("pubsub-topic-3")
+      PubSubTopic("pubsub-topic-1"),
+      PubSubTopic("pubsub-topic-2"),
+      PubSubTopic("pubsub-topic-3")
     ]
     discard await client.relayPostSubscriptionsV1(newTopics)
     
     let response = await client.relayPostMessagesV1(DefaultPubsubTopic, RelayWakuMessage(
       payload: Base64String.encode("TEST-PAYLOAD"), 
-      contentTopic: some(ContentTopicString(defaultContentTopic)), 
+      contentTopic: some(DefaultContentTopic), 
       timestamp: some(int64(2022))
     ))
 

--- a/tests/v2/test_rest_relay_api_serdes.nim
+++ b/tests/v2/test_rest_relay_api_serdes.nim
@@ -8,7 +8,8 @@ import
 import 
   ../../waku/v2/node/rest/serdes,
   ../../waku/v2/node/rest/base64,
-  ../../waku/v2/node/rest/relay/api_types
+  ../../waku/v2/node/rest/relay/api_types,
+  ../../waku/v2/protocol/waku_message
 
 
 suite "Relay API - serialization":
@@ -36,8 +37,8 @@ suite "Relay API - serialization":
       # Given
       let payload = Base64String.encode("MESSAGE")
       let data = RelayWakuMessage(
-        payload: payload, 
-        contentTopic: none(ContentTopicString),
+        payload: payload,
+        contentTopic: none(ContentTopic),
         version: none(Natural),
         timestamp: none(int64)
       )

--- a/waku/v2/node/jsonrpc/jsonrpc_utils.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_utils.nim
@@ -44,7 +44,6 @@ proc toStoreResponse*(historyResponse: HistoryResponse): StoreResponse =
                 pagingOptions: if historyResponse.pagingInfo != PagingInfo(): some(historyResponse.pagingInfo.toPagingOptions()) else: none(StorePagingOptions))
 
 proc toWakuMessage*(relayMessage: WakuRelayMessage, version: uint32): WakuMessage =
-  const defaultCT = ContentTopic("/waku/2/default-content/proto")
   var t: Timestamp
   if relayMessage.timestamp.isSome: 
     t = relayMessage.timestamp.get 
@@ -52,14 +51,11 @@ proc toWakuMessage*(relayMessage: WakuRelayMessage, version: uint32): WakuMessag
     # incoming WakuRelayMessages with no timestamp will get 0 timestamp
     t = Timestamp(0)
   WakuMessage(payload: relayMessage.payload,
-              contentTopic: if relayMessage.contentTopic.isSome: relayMessage.contentTopic.get else: defaultCT,
+              contentTopic: relayMessage.contentTopic.get(DefaultContentTopic),
               version: version,
               timestamp: t) 
 
 proc toWakuMessage*(relayMessage: WakuRelayMessage, version: uint32, rng: ref HmacDrbgContext, symkey: Option[SymKey], pubKey: Option[keys.PublicKey]): WakuMessage =
-  # @TODO global definition for default content topic
-  const defaultCT = ContentTopic("/waku/2/default-content/proto")
-
   let payload = Payload(payload: relayMessage.payload,
                         dst: pubKey,
                         symkey: symkey)
@@ -72,13 +68,11 @@ proc toWakuMessage*(relayMessage: WakuRelayMessage, version: uint32, rng: ref Hm
     t = Timestamp(0)
 
   WakuMessage(payload: payload.encode(version, rng[]).get(),
-              contentTopic: if relayMessage.contentTopic.isSome: relayMessage.contentTopic.get else: defaultCT,
+              contentTopic: relayMessage.contentTopic.get(DefaultContentTopic),
               version: version,
               timestamp: t) 
 
 proc toWakuRelayMessage*(message: WakuMessage, symkey: Option[SymKey], privateKey: Option[keys.PrivateKey]): WakuRelayMessage =
-  # @TODO global definition for default content topic
-
   let
     keyInfo = if symkey.isSome(): KeyInfo(kind: Symmetric, symKey: symkey.get()) 
               elif privateKey.isSome(): KeyInfo(kind: Asymmetric, privKey: privateKey.get())

--- a/waku/v2/node/rest/relay/relay_api.nim
+++ b/waku/v2/node/rest/relay/relay_api.nim
@@ -12,6 +12,7 @@ import
   presto/[route, client, common]
 import 
   ../../waku_node,
+  ../../../protocol/waku_message,
   ../serdes,
   ../utils,
   ./api_types, 
@@ -157,7 +158,7 @@ proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, topicCache
 
 #### Client
 
-proc encodeBytes*(value: seq[PubSubTopicString],
+proc encodeBytes*(value: seq[PubSubTopic],
                   contentType: string): RestResult[seq[byte]] =
   if MediaType.init(contentType) != MIMETYPE_JSON:
     error "Unsupported contentType value", contentType = contentType

--- a/waku/v2/node/rest/relay/topic_cache.nim
+++ b/waku/v2/node/rest/relay/topic_cache.nim
@@ -20,11 +20,9 @@ export message_cache
 
 ##### TopicCache
 
-type PubSubTopicString = string 
-
 type TopicCacheResult*[T] = MessageCacheResult[T]
 
-type TopicCache* = MessageCache[PubSubTopicString]
+type TopicCache* = MessageCache[PubSubTopic]
 
 
 ##### Message handler
@@ -33,17 +31,17 @@ type TopicCacheMessageHandler* = Topichandler
 
 proc messageHandler*(cache: TopicCache): TopicCacheMessageHandler =
 
-  let handler = proc(topic: string, data: seq[byte]): Future[void] {.async, closure.} =
-    trace "Topic handler triggered", topic=topic
+  let handler = proc(pubsubTopic: string, data: seq[byte]): Future[void] {.async, closure.} =
+    trace "PubsubTopic handler triggered", pubsubTopic=pubsubTopic
 
     # Add message to current cache
     let msg = WakuMessage.decode(data)
     if msg.isErr():
-      debug "WakuMessage received but failed to decode", msg=msg, topic=topic
+      debug "WakuMessage received but failed to decode", msg=msg, pubsubTopic=pubsubTopic
       # TODO: handle message decode failure
       return
 
-    trace "WakuMessage received", msg=msg, topic=topic
-    cache.addMessage(PubSubTopicString(topic), msg.get())
+    trace "WakuMessage received", msg=msg, pubsubTopic=pubsubTopic
+    cache.addMessage(PubSubTopic(pubsubTopic), msg.get())
   
   handler

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -347,7 +347,7 @@ proc startRelay*(node: WakuNode) {.async.} =
   info "starting relay"
   
   # PubsubTopic subscriptions
-  for topic in node.wakuRelay.defaultTopics:
+  for topic in node.wakuRelay.defaultPubsubTopics:
     node.subscribe(topic, none(TopicHandler))
 
   # Resume previous relay connections
@@ -393,7 +393,7 @@ proc mountRelay*(node: WakuNode,
 
   ## The default relay topics is the union of
   ## all configured topics plus the hard-coded defaultTopic(s)
-  wakuRelay.defaultTopics = concat(@[DefaultPubsubTopic], topics)
+  wakuRelay.defaultPubsubTopics = concat(@[DefaultPubsubTopic], topics)
 
   ## Add peer exchange handler
   if peerExchangeHandler.isSome():

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -27,8 +27,8 @@ type
   ContentTopic* = string
 
 const 
-  DefaultPubsubTopic*: PubsubTopic = "/waku/2/default-waku/proto"
-  DefaultContentTopic*: ContentTopic = "/waku/2/default-content/proto"
+  DefaultPubsubTopic*: PubsubTopic = PubsubTopic("/waku/2/default-waku/proto")
+  DefaultContentTopic*: ContentTopic = ContentTopic("/waku/2/default-content/proto")
 
 
 type WakuMessage* = object

--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -25,7 +25,7 @@ const
 
 type
   WakuRelay* = ref object of GossipSub
-    defaultTopics*: seq[PubsubTopic] # Default configured PubSub topics
+    defaultPubsubTopics*: seq[PubsubTopic] # Default configured PubSub topics
 
 method init*(w: WakuRelay) =
   debug "init WakuRelay"

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1115,7 +1115,7 @@ proc mountRlnRelayStatic*(node: WakuNode,
   if node.wakuRelay.isNil():
     return err("WakuRelay protocol is not mounted")
   # check whether the pubsub topic is supported at the relay level
-  if pubsubTopic notin node.wakuRelay.defaultTopics:
+  if pubsubTopic notin node.wakuRelay.defaultPubsubTopics:
     return err("The relay protocol does not support the configured pubsub topic")
 
   debug "rln-relay input validation passed"
@@ -1170,7 +1170,7 @@ proc mountRlnRelayDynamic*(node: WakuNode,
   if node.wakuRelay.isNil:
     return err("WakuRelay protocol is not mounted.")
   # check whether the pubsub topic is supported at the relay level
-  if pubsubTopic notin node.wakuRelay.defaultTopics:
+  if pubsubTopic notin node.wakuRelay.defaultPubsubTopics:
     return err("WakuRelay protocol does not support the configured pubsub topic.")
   debug "rln-relay input validation passed"
 


### PR DESCRIPTION
* Resolves [comment1](https://github.com/status-im/nwaku/pull/1352/files#r1016901351) from #1352
* Resolves [comment2](https://github.com/status-im/nwaku/pull/1352/files#r1016897936) from #1352

Summary:
* General refactor using `PubsubTopic` and `ContentTopic` fields.
* Reuse default values for both fields introduced in #1352
* Removes `PubsubTopicString` and its usages.
* Enforce `defaultPubsubTopics` instead of `defaultTopics`

As a general note, which I think @LNSD agrees with me, we should be specific using `pubsub` or `content` instead of just using `topic`. As it may be confusing.
