### PR TITLE
fix: move stopGanache/uninstallGanache to teardown

### DIFF
--- a/tests/v2/test_waku_rln_relay_onchain.nim
+++ b/tests/v2/test_waku_rln_relay_onchain.nim
@@ -605,12 +605,13 @@ procSuite "Waku-rln-relay":
     await node.stop()
     await node2.stop()
 
+
   ################################
   ## Terminating/removing Ganache
   ################################
+  teardown:
+    # We stop Ganache daemon
+    stopGanache(runGanache)
 
-  # We stop Ganache daemon
-  stopGanache(runGanache)
-
-  # We uninstall Ganache
-  uninstallGanache()
+    # We uninstall Ganache
+    uninstallGanache()


### PR DESCRIPTION
Looks like there are some problems with macOs tests and RLN. Haven't been able to reproduce the issue, but looking at a ok build and nok build, everything seems to point to `uninstallGanache()`.


NOK build
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/8811422/200848535-61d10faf-a943-4930-89a5-83530c635e67.png">

OK build
<img width="1301" alt="image" src="https://user-images.githubusercontent.com/8811422/200848750-5618cfbd-b2d3-43ee-9552-b97ce4a12cbb.png">


So everything seems to point out to `uninstallGanache()`.

WIP: This PR is debugging the issue.
Ideas:
* using `teardown` might help?