### PR TITLE
chore: disable store protocol by default

### DIFF
--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -196,7 +196,7 @@ type
 
     store* {.
       desc: "Enable/disable waku store protocol",
-      defaultValue: true,
+      defaultValue: false,
       name: "store" }: bool
 
     storenode* {.

--- a/docs/operators/how-to/configure-store.md
+++ b/docs/operators/how-to/configure-store.md
@@ -2,11 +2,11 @@
 
 > :information_source: This instructions apply to nwaku version v0.13.0+. For versions prior to v0.13.0, check [this page](./configure-store-v0.12.0.md).
 
-The waku store protocol is enabled by default the nwaku node.
-This is controlled by the `--store` option. To disable waku store protocol on startup, specify explicitly the `--store` option set to `false`:
+The waku store protocol is disabled by default the nwaku node.
+This is controlled by the `--store` option. To enable waku store protocol on startup, specify explicitly the `--store` option set to `true`:
 
 ```shell
-wakunode2 --store=false
+wakunode2 --store=true
 ```
 
 This option controls the mounting of the Waku Store protocol, meaning that your node will indicate to other peers that it supports the Waku store protocol.


### PR DESCRIPTION
Opening this suggestion as a PR, because I believe it should be done before the release if we agree upon it.

Disables `store` protocol by default.

## Reasoning

One of the most important considerations for configuration is to have good defaults. I believe the default for `store` (which now implies actually persisting historical messages) should be `false`:
- the 95% use case for running a nwaku node is "run a `relay`-only node" - this should be the reasonable default
- this use case should not preclude such nodes from querying store nodes as a client. This is now always the case, even with `store` disabled.
- previously persisting messages would have been disabled by default (via the now deprecated `persist-messages` option)
- operators who upgrade their relay nodes and previously didn't care about or configure store will now suddenly start storing messages unless they change their config, especially a problem for those on resource-restricted devices.

## TL;DR

To work as it did before `store` should now by default be `false`. I think this is the most reasonable default use case. :D