### PR TITLE
feat(rln-relay): mounting proc waku_node, barrel imports

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -38,7 +38,7 @@ when defined(rln):
   import
     libp2p/protocols/pubsub/rpc/messages,
     libp2p/protocols/pubsub/pubsub,
-    ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils
+    ../../waku/v2/protocol/waku_rln_relay
 
 const Help = """
   Commands: /[?|help|connect|nick|exit]

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -47,8 +47,7 @@ import
 
 when defined(rln):
   import
-    ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_types,
-    ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils
+    ../../waku/v2/protocol/waku_rln_relay
 
 
 logScope:
@@ -373,9 +372,7 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
       )
 
       try: 
-        let res = await node.mountRlnRelay(rlnConf)
-        if res.isErr():
-          return err("failed to mount waku RLN relay protocol: " & res.error)
+        await node.mountRlnRelay(rlnConf)
       except:
         return err("failed to mount waku RLN relay protocol: " & getCurrentExceptionMsg())
   

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -13,11 +13,7 @@ import
 import
   ../../waku/v2/node/waku_node,
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/protocol/waku_rln_relay/rln, 
-  ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils,
-  ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_types,
-  ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_constants,
-  ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_metrics,
+  ../../waku/v2/protocol/waku_rln_relay,
   ../test_helpers
 
 const RlnRelayPubsubTopic = "waku/2/rlnrelay/proto"

--- a/tests/v2/test_waku_rln_relay_onchain.nim
+++ b/tests/v2/test_waku_rln_relay_onchain.nim
@@ -8,10 +8,7 @@ import
   stew/byteutils, stew/shims/net as stewNet,
   libp2p/crypto/crypto,
   eth/keys,
-  ../../waku/v2/protocol/waku_rln_relay/[waku_rln_relay_utils,
-      waku_rln_relay_constants,
-      waku_rln_relay_types, 
-      rln_relay_contract],
+  ../../waku/v2/protocol/waku_rln_relay,
   ../../waku/v2/node/waku_node,
   ../test_helpers,
   ./test_utils

--- a/tests/v2/test_wakunode_rln_relay.nim
+++ b/tests/v2/test_wakunode_rln_relay.nim
@@ -17,9 +17,7 @@ import
 import
   ../../waku/v2/node/waku_node,
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils,
-  ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_types,
-  ../../waku/v2/protocol/waku_rln_relay/waku_rln_relay_constants,
+  ../../waku/v2/protocol/waku_rln_relay,
   ../../waku/v2/utils/peers
 
 from std/times import epochTime

--- a/waku/v2/node/waku_metrics.nim
+++ b/waku/v2/node/waku_metrics.nim
@@ -17,7 +17,7 @@ import
   ./waku_node
 
 when defined(rln):
-  import ../protocol/waku_rln_relay/waku_rln_relay_metrics
+  import ../protocol/waku_rln_relay
 
 
 const LogInterval = 30.seconds

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -781,8 +781,8 @@ proc setPeerExchangePeer*(node: WakuNode, peer: RemotePeerInfo|string) {.raises:
 proc mountRlnRelay*(node: WakuNode, rlnConf: WakuRlnConfig) {.async.} =
   info "mounting rln relay"
 
-  let rlnRelayRes = await WakuRlnRelay.init(node.wakuRelay, 
-                                            rlnConf)
+  let rlnRelayRes = await WakuRlnRelay.new(node.wakuRelay, 
+                                           rlnConf)
   if rlnRelayRes.isErr():
     error "failed to mount rln relay", error=rlnRelayRes.error
     return

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -44,7 +44,7 @@ import
 
 when defined(rln):
   import
-    ../protocol/waku_rln_relay/waku_rln_relay_types
+    ../protocol/waku_rln_relay
 
 declarePublicGauge waku_version, "Waku version info (in git describe format)", ["version"]
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]
@@ -776,6 +776,17 @@ proc setPeerExchangePeer*(node: WakuNode, peer: RemotePeerInfo|string) {.raises:
   node.peerManager.addPeer(remotePeer, WakuPeerExchangeCodec)
   waku_px_peers.inc()
 
+## Waku RLN Relay
+
+proc mountRlnRelay*(node: WakuNode, rlnConf: WakuRlnConfig) {.async.} =
+  info "mounting rln relay"
+
+  let rlnRelayRes = await WakuRlnRelay.init(node.wakuRelay, 
+                                            rlnConf)
+  if rlnRelayRes.isErr():
+    error "failed to mount rln relay", error=rlnRelayRes.error
+    return
+  node.wakuRlnRelay = rlnRelayRes.get()
 
 ## Other protocols
 

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -777,16 +777,16 @@ proc setPeerExchangePeer*(node: WakuNode, peer: RemotePeerInfo|string) {.raises:
   waku_px_peers.inc()
 
 ## Waku RLN Relay
+when defined(rln):
+  proc mountRlnRelay*(node: WakuNode, rlnConf: WakuRlnConfig) {.async.} =
+    info "mounting rln relay"
 
-proc mountRlnRelay*(node: WakuNode, rlnConf: WakuRlnConfig) {.async.} =
-  info "mounting rln relay"
-
-  let rlnRelayRes = await WakuRlnRelay.new(node.wakuRelay, 
-                                           rlnConf)
-  if rlnRelayRes.isErr():
-    error "failed to mount rln relay", error=rlnRelayRes.error
-    return
-  node.wakuRlnRelay = rlnRelayRes.get()
+    let rlnRelayRes = await WakuRlnRelay.new(node.wakuRelay, 
+                                             rlnConf)
+    if rlnRelayRes.isErr():
+      error "failed to mount rln relay", error=rlnRelayRes.error
+      return
+    node.wakuRlnRelay = rlnRelayRes.get()
 
 ## Other protocols
 

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -19,6 +19,7 @@ import
   ../utils/time
 
 when defined(rln):
+  # Only requires the RateLimitProof type
   import
     ./waku_rln_relay/waku_rln_relay_types
 
@@ -40,10 +41,10 @@ type WakuMessage* = object
     version*: uint32
     # sender generated timestamp
     timestamp*: Timestamp
-    # the proof field indicates that the message is not a spam
-    # this field will be used in the rln-relay protocol
-    # XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec and not yet part of WakuMessage spec
     when defined(rln):
+      # the proof field indicates that the message is not a spam
+      # this field will be used in the rln-relay protocol
+      # XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec and not yet part of WakuMessage spec 
       proof*: RateLimitProof
     # The ephemeral field indicates if the message should
     # be stored. bools and uints are 

--- a/waku/v2/protocol/waku_rln_relay.nim
+++ b/waku/v2/protocol/waku_rln_relay.nim
@@ -1,0 +1,13 @@
+import
+  ./waku_rln_relay/rln,
+  ./waku_rln_relay/waku_rln_relay_constants,
+  ./waku_rln_relay/waku_rln_relay_types,
+  ./waku_rln_relay/waku_rln_relay_utils,
+  ./waku_rln_relay/waku_rln_relay_metrics
+
+export
+  rln,
+  waku_rln_relay_constants,
+  waku_rln_relay_types,
+  waku_rln_relay_utils,
+  waku_rln_relay_metrics

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -21,8 +21,8 @@ import
   waku_rln_relay_metrics,
   ../../utils/time,
   ../../utils/keyfile,
-  ../../node/waku_node,
-  ../waku_message
+  ../waku_message,
+  ../waku_relay
 
 logScope:
   topics = "waku rln_relay"
@@ -946,7 +946,11 @@ proc handleGroupUpdates*(rlnPeer: WakuRLNRelay) {.async, gcsafe.} =
                                contractAddress = rlnPeer.membershipContractAddress,
                                handler = handler)
   
-proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopic: ContentTopic, spamHandler: Option[SpamHandler] = none(SpamHandler)) =
+proc addRLNRelayValidator*(wakuRlnRelay: WakuRLNRelay,
+                           wakuRelay: WakuRelay,
+                           pubsubTopic: PubsubTopic, 
+                           contentTopic: ContentTopic, 
+                           spamHandler: Option[SpamHandler] = none(SpamHandler)) =
   ## this procedure is a thin wrapper for the pubsub addValidator method
   ## it sets a validator for the waku messages published on the supplied pubsubTopic and contentTopic 
   ## if contentTopic is empty, then validation takes place for All the messages published on the given pubsubTopic
@@ -966,7 +970,7 @@ proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopi
 
       # validate the message
       let 
-        validationRes = node.wakuRlnRelay.validateMessage(wakumessage)
+        validationRes = wakuRlnRelay.validateMessage(wakumessage)
         proof = toHex(wakumessage.proof.proof)
         epoch = fromEpoch(wakumessage.proof.epoch)
         root = inHex(wakumessage.proof.merkleRoot)
@@ -990,28 +994,19 @@ proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopi
             handler(wakumessage)
           return pubsub.ValidationResult.Reject          
   # set a validator for the supplied pubsubTopic 
-  let pb  = PubSub(node.wakuRelay)
+  let pb  = PubSub(wakuRelay)
   pb.addValidator(pubsubTopic, validator)
 
-proc mountRlnRelayStatic*(node: WakuNode,
-                    group: seq[IDCommitment],
-                    memKeyPair: MembershipKeyPair,
-                    memIndex: MembershipIndex,
-                    pubsubTopic: PubsubTopic,
-                    contentTopic: ContentTopic,
-                    spamHandler: Option[SpamHandler] = none(SpamHandler)): RlnRelayResult[void] =
+proc mountRlnRelayStatic*(wakuRelay: WakuRelay,
+                          group: seq[IDCommitment],
+                          memKeyPair: MembershipKeyPair,
+                          memIndex: MembershipIndex,
+                          pubsubTopic: PubsubTopic,
+                          contentTopic: ContentTopic,
+                          spamHandler: Option[SpamHandler] = none(SpamHandler)): RlnRelayResult[WakuRlnRelay] =
   # Returns RlnRelayResult[void] to indicate the success of the call
 
   debug "mounting rln-relay in off-chain/static mode"
-  # check whether inputs are provided
-  # relay protocol is the prerequisite of rln-relay
-  if node.wakuRelay.isNil():
-    return err("WakuRelay protocol is not mounted")
-  # check whether the pubsub topic is supported at the relay level
-  if pubsubTopic notin node.wakuRelay.defaultPubsubTopics:
-    return err("The relay protocol does not support the configured pubsub topic")
-
-  debug "rln-relay input validation passed"
 
   # check the peer's index and the inclusion of user's identity commitment in the group
   if not memKeyPair.idCommitment  == group[int(memIndex)]:
@@ -1038,32 +1033,23 @@ proc mountRlnRelayStatic*(node: WakuNode,
   # adds a topic validator for the supplied pubsub topic at the relay protocol
   # messages published on this pubsub topic will be relayed upon a successful validation, otherwise they will be dropped
   # the topic validator checks for the correct non-spamming proof of the message
-  node.addRLNRelayValidator(pubsubTopic, contentTopic, spamHandler)
+  rlnPeer.addRLNRelayValidator(wakuRelay, pubsubTopic, contentTopic, spamHandler)
   debug "rln relay topic validator is mounted successfully", pubsubTopic=pubsubTopic, contentTopic=contentTopic
 
-  node.wakuRlnRelay = rlnPeer
-  return ok()  
+  return ok(rlnPeer)  
 
-proc mountRlnRelayDynamic*(node: WakuNode,
-                    ethClientAddr: string = "",
-                    ethAccountAddress: Option[web3.Address] = none(web3.Address),
-                    ethAccountPrivKeyOpt: Option[keys.PrivateKey],
-                    memContractAddr:  web3.Address,
-                    memKeyPair: Option[MembershipKeyPair] = none(MembershipKeyPair),
-                    memIndex: Option[MembershipIndex] = none(MembershipIndex),
-                    pubsubTopic: PubsubTopic,
-                    contentTopic: ContentTopic,
-                    spamHandler: Option[SpamHandler] = none(SpamHandler),
-                    registrationHandler: Option[RegistrationHandler] = none(RegistrationHandler)) : Future[RlnRelayResult[void]] {.async.} =
+proc mountRlnRelayDynamic*(wakuRelay: WakuRelay,
+                           ethClientAddr: string = "",
+                           ethAccountAddress: Option[web3.Address] = none(web3.Address),
+                           ethAccountPrivKeyOpt: Option[keys.PrivateKey],
+                           memContractAddr:  web3.Address,
+                           memKeyPair: Option[MembershipKeyPair] = none(MembershipKeyPair),
+                           memIndex: Option[MembershipIndex] = none(MembershipIndex),
+                           pubsubTopic: PubsubTopic,
+                           contentTopic: ContentTopic,
+                           spamHandler: Option[SpamHandler] = none(SpamHandler),
+                           registrationHandler: Option[RegistrationHandler] = none(RegistrationHandler)) : Future[RlnRelayResult[WakuRlnRelay]] {.async.} =
   debug "mounting rln-relay in on-chain/dynamic mode"
-  # TODO return a bool value to indicate the success of the call
-  # relay protocol is the prerequisite of rln-relay
-  if node.wakuRelay.isNil:
-    return err("WakuRelay protocol is not mounted.")
-  # check whether the pubsub topic is supported at the relay level
-  if pubsubTopic notin node.wakuRelay.defaultPubsubTopics:
-    return err("WakuRelay protocol does not support the configured pubsub topic.")
-  debug "rln-relay input validation passed"
 
   # create an RLN instance
   let rlnInstance = createRLNInstance()
@@ -1121,11 +1107,10 @@ proc mountRlnRelayDynamic*(node: WakuNode,
   # adds a topic validator for the supplied pubsub topic at the relay protocol
   # messages published on this pubsub topic will be relayed upon a successful validation, otherwise they will be dropped
   # the topic validator checks for the correct non-spamming proof of the message
-  addRLNRelayValidator(node, pubsubTopic, contentTopic, spamHandler)
+  rlnPeer.addRLNRelayValidator(wakuRelay, pubsubTopic, contentTopic, spamHandler)
   debug "rln relay topic validator is mounted successfully", pubsubTopic=pubsubTopic, contentTopic=contentTopic
 
-  node.wakuRlnRelay = rlnPeer
-  return ok()
+  return ok(rlnPeer)
 
 proc writeRlnCredentials*(path: string, 
                           credentials: RlnMembershipCredentials, 
@@ -1172,12 +1157,12 @@ proc readRlnCredentials*(path: string,
     except:
       return err("Error while loading keyfile for RLN credentials at " & path)
 
-proc mount(node: WakuNode,
+proc mount(wakuRelay: WakuRelay,
            conf: WakuRlnConfig,
            spamHandler: Option[SpamHandler] = none(SpamHandler),
            registrationHandler: Option[RegistrationHandler] = none(RegistrationHandler)
-          ): Future[RlnRelayResult[void]] {.async.} =
-  # Returns RlnRelayResult[void], which indicates the success of the call
+          ): Future[RlnRelayResult[WakuRlnRelay]] {.async.} =
+  # Returns RlnRelayResult[WakuRlnRelay]
   if not conf.rlnRelayDynamic:
     info " setting up waku-rln-relay in off-chain mode... "
     # set up rln relay inputs
@@ -1185,20 +1170,23 @@ proc mount(node: WakuNode,
     if staticSetupRes.isErr():
       return err("rln relay static setup failed: " & staticSetupRes.error())
     let (groupOpt, memKeyPairOpt, memIndexOpt) = staticSetupRes.get()
-    if memIndexOpt.isNone:
+    if memIndexOpt.isNone():
       error "failed to mount WakuRLNRelay"
       return err("failed to mount WakuRLNRelay")
     else:
       # mount rlnrelay in off-chain mode with a static group of users
-      let mountRes = node.mountRlnRelayStatic(group = groupOpt.get(), 
-                               memKeyPair = memKeyPairOpt.get(),
-                               memIndex= memIndexOpt.get(), 
-                               pubsubTopic = conf.rlnRelayPubsubTopic,
-                               contentTopic = conf.rlnRelayContentTopic, 
-                               spamHandler = spamHandler)
+      let mountRes = mountRlnRelayStatic(wakuRelay,
+                                         group = groupOpt.get(), 
+                                         memKeyPair = memKeyPairOpt.get(),
+                                         memIndex = memIndexOpt.get(), 
+                                         pubsubTopic = conf.rlnRelayPubsubTopic,
+                                         contentTopic = conf.rlnRelayContentTopic, 
+                                         spamHandler = spamHandler)
 
       if mountRes.isErr():
         return err("Failed to mount WakuRLNRelay: " & mountRes.error())
+
+      let rlnRelay = mountRes.get()
 
       info "membership id key", idkey=memKeyPairOpt.get().idKey.inHex()
       info "membership id commitment key", idCommitmentkey=memKeyPairOpt.get().idCommitment.inHex()
@@ -1207,7 +1195,7 @@ proc mount(node: WakuNode,
       # no error should happen as it is already captured in the unit tests
       # TODO have added this check to account for unseen corner cases, will remove it later 
       let 
-        rootRes = node.wakuRlnRelay.rlnInstance.getMerkleRoot()
+        rootRes = rlnRelay.rlnInstance.getMerkleRoot()
         expectedRoot = StaticGroupMerkleRoot
       
       if rootRes.isErr():
@@ -1219,7 +1207,7 @@ proc mount(node: WakuNode,
         error "root mismatch: something went wrong not in Merkle tree construction"
       debug "the calculated root", root
       info "WakuRLNRelay is mounted successfully", pubsubtopic=conf.rlnRelayPubsubTopic, contentTopic=conf.rlnRelayContentTopic
-      return ok()
+      return ok(rlnRelay)
   else: # mount the rln relay protocol in the on-chain/dynamic mode
     debug "setting up waku-rln-relay in on-chain mode... "
     
@@ -1236,7 +1224,9 @@ proc mount(node: WakuNode,
     var ethAccountPrivKeyOpt = none(keys.PrivateKey)
     var ethAccountAddressOpt = none(Address)
     var credentials = none(RlnMembershipCredentials)
-    var res: RlnRelayResult[void]
+    var rlnRelayRes: RlnRelayResult[WakuRlnRelay]
+    var rlnRelayCredPath: string
+    var persistCredentials: bool = false
 
     if conf.rlnRelayEthAccountPrivateKey != "":
       ethAccountPrivKeyOpt = some(keys.PrivateKey(SkSecretKey.fromHex(conf.rlnRelayEthAccountPrivateKey).value))
@@ -1254,7 +1244,7 @@ proc mount(node: WakuNode,
     # if there is a credential file, then no new credentials are generated, instead the content of the file is read and used to mount rln-relay 
     if conf.rlnRelayCredPath != "": 
       
-      let rlnRelayCredPath = joinPath(conf.rlnRelayCredPath, RlnCredentialsFilename)
+      rlnRelayCredPath = joinPath(conf.rlnRelayCredPath, RlnCredentialsFilename)
       debug "rln-relay credential path", rlnRelayCredPath
       
       # check if there is an rln-relay credential file in the supplied path
@@ -1266,7 +1256,7 @@ proc mount(node: WakuNode,
         let readCredentialsRes = readRlnCredentials(rlnRelayCredPath, conf.rlnRelayCredentialsPassword)
         
         if readCredentialsRes.isErr():
-            return err("RLN credentials cannot be read: " & readCredentialsRes.error())
+          return err("RLN credentials cannot be read: " & readCredentialsRes.error())
 
         credentials = readCredentialsRes.get()
 
@@ -1277,59 +1267,82 @@ proc mount(node: WakuNode,
         
       if credentials.isSome():
         # mount rln-relay in on-chain mode, with credentials that were read or generated
-        res = await node.mountRlnRelayDynamic(memContractAddr = ethMemContractAddress, 
-                                                ethClientAddr = ethClientAddr,
-                                                ethAccountAddress = ethAccountAddressOpt, 
-                                                ethAccountPrivKeyOpt = ethAccountPrivKeyOpt, 
-                                                pubsubTopic = conf.rlnRelayPubsubTopic,
-                                                contentTopic = conf.rlnRelayContentTopic, 
-                                                spamHandler = spamHandler, 
-                                                registrationHandler = registrationHandler,
-                                                memKeyPair = some(credentials.get().membershipKeyPair),
-                                                memIndex = some(credentials.get().rlnIndex))  
+        rlnRelayRes = await mountRlnRelayDynamic(wakuRelay,
+                                                 memContractAddr = ethMemContractAddress, 
+                                                 ethClientAddr = ethClientAddr,
+                                                 ethAccountAddress = ethAccountAddressOpt, 
+                                                 ethAccountPrivKeyOpt = ethAccountPrivKeyOpt, 
+                                                 pubsubTopic = conf.rlnRelayPubsubTopic,
+                                                 contentTopic = conf.rlnRelayContentTopic, 
+                                                 spamHandler = spamHandler, 
+                                                 registrationHandler = registrationHandler,
+                                                 memKeyPair = some(credentials.get().membershipKeyPair),
+                                                 memIndex = some(credentials.get().rlnIndex))  
       else:
         # mount rln-relay in on-chain mode, with the provided private key 
-        res = await node.mountRlnRelayDynamic(memContractAddr = ethMemContractAddress, 
-                                                ethClientAddr = ethClientAddr,
-                                                ethAccountAddress = ethAccountAddressOpt, 
-                                                ethAccountPrivKeyOpt = ethAccountPrivKeyOpt, 
-                                                pubsubTopic = conf.rlnRelayPubsubTopic,
-                                                contentTopic = conf.rlnRelayContentTopic, 
-                                                spamHandler = spamHandler, 
-                                                registrationHandler = registrationHandler)
-                
-        # TODO should be replaced with key-store with proper encryption
-        # persist rln credential
-        credentials = some(RlnMembershipCredentials(rlnIndex: node.wakuRlnRelay.membershipIndex, 
-                                                    membershipKeyPair: node.wakuRlnRelay.membershipKeyPair))
-        if writeRlnCredentials(rlnRelayCredPath, credentials.get(), conf.rlnRelayCredentialsPassword).isErr():
-          return err("error in storing rln credentials")
+        rlnRelayRes = await mountRlnRelayDynamic(wakuRelay,
+                                                 memContractAddr = ethMemContractAddress, 
+                                                 ethClientAddr = ethClientAddr,
+                                                 ethAccountAddress = ethAccountAddressOpt, 
+                                                 ethAccountPrivKeyOpt = ethAccountPrivKeyOpt, 
+                                                 pubsubTopic = conf.rlnRelayPubsubTopic,
+                                                 contentTopic = conf.rlnRelayContentTopic, 
+                                                 spamHandler = spamHandler, 
+                                                 registrationHandler = registrationHandler)
+        
+        persistCredentials = true
 
     else:
       # do not persist or use a persisted rln-relay credential
       # a new credential will be generated during the mount process but will not be persisted
       info "no need to persist or use a persisted rln-relay credential"
-      res = await node.mountRlnRelayDynamic(memContractAddr = ethMemContractAddress, ethClientAddr = ethClientAddr,
-                ethAccountAddress = ethAccountAddressOpt, ethAccountPrivKeyOpt = ethAccountPrivKeyOpt, pubsubTopic = conf.rlnRelayPubsubTopic,
-                contentTopic = conf.rlnRelayContentTopic, spamHandler = spamHandler, registrationHandler = registrationHandler)
+      rlnRelayRes = await mountRlnRelayDynamic(wakuRelay,
+                                               memContractAddr = ethMemContractAddress, 
+                                               ethClientAddr = ethClientAddr,
+                                               ethAccountAddress = ethAccountAddressOpt, 
+                                               ethAccountPrivKeyOpt = ethAccountPrivKeyOpt, 
+                                               pubsubTopic = conf.rlnRelayPubsubTopic,
+                                               contentTopic = conf.rlnRelayContentTopic, 
+                                               spamHandler = spamHandler, 
+                                               registrationHandler = registrationHandler)
       
-    if res.isErr():
-      return err("dynamic rln-relay could not be mounted: " & res.error())
-    return ok()
+    if rlnRelayRes.isErr():
+      return err("dynamic rln-relay could not be mounted: " & rlnRelayRes.error())
 
-proc mountRlnRelay*(node: WakuNode,
-                    conf: WakuRlnConfig,
-                    spamHandler: Option[SpamHandler] = none(SpamHandler),
-                    registrationHandler: Option[RegistrationHandler] = none(RegistrationHandler)
-                   ): Future[RlnRelayResult[void]] {.async.} =
+    let wakuRlnRelay = rlnRelayRes.get()
+    if persistCredentials:
+      # TODO should be replaced with key-store with proper encryption
+      # persist rln credential
+      credentials = some(RlnMembershipCredentials(rlnIndex: wakuRlnRelay.membershipIndex, 
+                                                  membershipKeyPair: wakuRlnRelay.membershipKeyPair))
+      if writeRlnCredentials(rlnRelayCredPath, credentials.get(), conf.rlnRelayCredentialsPassword).isErr():
+        return err("error in storing rln credentials")
+    return ok(wakuRlnRelay)
+
+proc init*(T: type WakuRlnRelay,
+           wakuRelay: WakuRelay,
+           conf: WakuRlnConfig,
+           spamHandler: Option[SpamHandler] = none(SpamHandler),
+           registrationHandler: Option[RegistrationHandler] = none(RegistrationHandler)
+          ): Future[RlnRelayResult[WakuRlnRelay]] {.async.} =
   ## Mounts the rln-relay protocol on the node.
   ## The rln-relay protocol can be mounted in two modes: on-chain and off-chain.
   ## Returns an error if the rln-relay protocol could not be mounted.
+  
+  # check whether inputs are provided
+  # relay protocol is the prerequisite of rln-relay
+  if wakuRelay.isNil():
+    return err("WakuRelay protocol is not mounted")
+  # check whether the pubsub topic is supported at the relay level
+  if conf.rlnRelayPubsubTopic notin wakuRelay.defaultPubsubTopics:
+    return err("The relay protocol does not support the configured pubsub topic")
+
+  debug "rln-relay input validation passed"
   waku_rln_relay_mounting_duration_seconds.nanosecondTime: 
-    let res = await mount(
-      node,
+    let rlnRelayRes = await mount(
+      wakuRelay,
       conf,
       spamHandler,
       registrationHandler
     )
-  return res
+  return rlnRelayRes

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1319,7 +1319,7 @@ proc mount(wakuRelay: WakuRelay,
         return err("error in storing rln credentials")
     return ok(wakuRlnRelay)
 
-proc init*(T: type WakuRlnRelay,
+proc new*(T: type WakuRlnRelay,
            wakuRelay: WakuRelay,
            conf: WakuRlnConfig,
            spamHandler: Option[SpamHandler] = none(SpamHandler),


### PR DESCRIPTION
This PR cleans up the imports for rln-relay, and also makes the mounting procedure in line with other protocols.

- [x] Since waku-rln-relay depends on waku-relay, we pass in wakuRelay to the mounting procedure, instead of the node, clearing a cyclic dependency. (waku_node -> waku_rln_relay_utils -> waku_message -> waku_node)
- [x] Barrel for `waku_rln_relay` created so that only one import is required
- [x] `waku_rln_relay_types` specifically is required by `waku_message`, therefore only that module is imported. This should be cleaned up in the future.

Not included in the scope of this PR, but will be included in future PRs -
- [ ] Further refactoring to the mounting procedure of rln-relay in static/dynamic mode


