### PR TITLE
fix(ci): paths-ignore filter

### DIFF
--- a/.github/workflows/test1.yml
+++ b/.github/workflows/test1.yml
@@ -11,6 +11,10 @@ on:
       - 'metrics/**'
       - 'docs/**'
       - '**.md'
+
+      # Should run the workflow if changes are made to the following files
+      - '!waku/v1/**.nim'
+      - '!tests/v1/**.nim'
   push:
     branches:
       - master
@@ -19,6 +23,8 @@ on:
       - 'metrics/**'
       - 'docs/**'
       - '**.md'
+      - '!waku/v1/**.nim'
+      - '!tests/v1/**.nim'
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -15,6 +15,9 @@ on:
       - 'metrics/**'
       - 'docs/**'
       - '**.md'
+      # Should run the workflow if changes are made to the following files
+      - '!waku/v2/**.nim'
+      - '!tests/v2/**.nim'
   push:
     branches:
       - master
@@ -23,6 +26,8 @@ on:
       - 'metrics/**'
       - 'docs/**'
       - '**.md'
+      - '!waku/v2/**.nim'
+      - '!tests/v2/**.nim'
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -18,6 +18,9 @@ on:
       # Should run the workflow if changes are made to the following files
       - '!waku/v2/**.nim'
       - '!tests/v2/**.nim'
+      - '!tests/all_tests_v2.nim'
+      - '!apps/**/**.nim'
+      - '!tools/**/**.nim'
   push:
     branches:
       - master


### PR DESCRIPTION
The paths-ignore filter ignores changes if code and docs are updated together in one commit.

- fix(ci): when docs and code is changed, workflows run
- fix(ci): add more paths when workflow should run
