### PR TITLE
refactor(protocols): decouple protocol rpc types from api types

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -24,7 +24,7 @@ import libp2p/[switch,                   # manage transports, a single entry poi
                nameresolving/dnsresolver]# define DNS resolution
 import   
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/protocol/waku_lightpush,
+  ../../waku/v2/protocol/waku_lightpush/rpc,
   ../../waku/v2/protocol/waku_filter, 
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/node/[waku_node, waku_payload, waku_metrics],

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -28,6 +28,7 @@ import
   ../../waku/v2/protocol/waku_store/rpc,
   ../../waku/v2/protocol/waku_swap/waku_swap,
   ../../waku/v2/protocol/waku_filter,
+  ../../waku/v2/protocol/waku_filter/rpc,
   ../../waku/v2/protocol/waku_filter/client,
   ../../waku/v2/utils/peers,
   ../../waku/v2/utils/time,

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -15,6 +15,8 @@ import
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/discv5/waku_discv5,
   ../../waku/v2/protocol/waku_peer_exchange,
+  ../../waku/v2/protocol/waku_peer_exchange/rpc,
+  ../../waku/v2/protocol/waku_peer_exchange/rpc_codec,
   ../test_helpers,
   ./utils
 

--- a/tools/simulation/quicksim2.nim
+++ b/tools/simulation/quicksim2.nim
@@ -6,7 +6,7 @@ import
   json_rpc/[rpcclient, rpcserver],
   libp2p/protobuf/minprotobuf
 import
-  ../../waku/v2/protocol/waku_filter,
+  ../../waku/v2/protocol/waku_filter/rpc,
   ../../waku/v2/protocol/waku_store/rpc,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/utils/time,

--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -10,6 +10,7 @@ import
 import
   ../../protocol/waku_message,
   ../../protocol/waku_filter,
+  ../../protocol/waku_filter/rpc,
   ../../protocol/waku_filter/client,
   ../waku_node,
   ./jsonrpc_types

--- a/waku/v2/protocol/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter.nim
@@ -4,11 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  ./waku_filter/rpc,
-  ./waku_filter/rpc_codec,
   ./waku_filter/protocol
 
 export
-  rpc,
-  rpc_codec,
   protocol

--- a/waku/v2/protocol/waku_lightpush.nim
+++ b/waku/v2/protocol/waku_lightpush.nim
@@ -1,9 +1,5 @@
 import
-  ./waku_lightpush/protocol,
-  ./waku_lightpush/rpc,
-  ./waku_lightpush/rpc_codec
+  ./waku_lightpush/protocol
 
 export
-  protocol,
-  rpc,
-  rpc_codec
+  protocol

--- a/waku/v2/protocol/waku_peer_exchange.nim
+++ b/waku/v2/protocol/waku_peer_exchange.nim
@@ -4,10 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  ./waku_peer_exchange/rpc,
-  ./waku_peer_exchange/rpc_codec,
   ./waku_peer_exchange/protocol
+
 export
-  rpc,
-  rpc_codec,
   protocol


### PR DESCRIPTION
Protocol wire format types (a.k.a. "RPC types") should be decoupled from the exposed API and application types. The reasoning can be found [here](https://github.com/vacp2p/waku/pull/1#issuecomment-1313879596). 

As I already did previously with the Waku store protocol code, this PR aims to start the work of decoupling the "RPC types" from the "API/application types".

- [x] Do not re-export the RPC types. Or import them explicitly so, in the near future, the code can be refactored and decoupled.