### PR TITLE
chore: move protobuf module from utils to common

### DIFF
--- a/waku/common/protobuf.nim
+++ b/waku/common/protobuf.nim
@@ -1,3 +1,5 @@
+# Extensions for libp2p's protobuf library implementation
+
 when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
@@ -6,8 +8,11 @@ else:
 import
   libp2p/protobuf/minprotobuf,
   libp2p/varint
+ 
+export
+  minprotobuf,
+  varint
 
-# Collection of utilities related to protobuffer encoding
 
 proc write3*(proto: var ProtoBuffer, field: int, value: auto) =
   if default(type(value)) != value:

--- a/waku/v2/protocol/waku_filter/rpc_codec.nim
+++ b/waku/v2/protocol/waku_filter/rpc_codec.nim
@@ -4,10 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  libp2p/protobuf/minprotobuf,
-  libp2p/varint
-import
-  ../../utils/protobuf,
+  ../../../common/protobuf,
   ../waku_message,
   ./rpc
 

--- a/waku/v2/protocol/waku_lightpush/rpc_codec.nim
+++ b/waku/v2/protocol/waku_lightpush/rpc_codec.nim
@@ -5,9 +5,7 @@ else:
 
 
 import
-  libp2p/protobuf/minprotobuf
-import
-  ../../utils/protobuf,
+  ../../../common/protobuf,
   ../waku_message,
   ./rpc
 

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -12,10 +12,7 @@ else:
 
 
 import
-  libp2p/protobuf/minprotobuf,
-  libp2p/varint
-import
-  ../utils/protobuf,
+  ../../common/protobuf,
   ../utils/time
 
 when defined(rln):

--- a/waku/v2/protocol/waku_peer_exchange/rpc_codec.nim
+++ b/waku/v2/protocol/waku_peer_exchange/rpc_codec.nim
@@ -5,10 +5,7 @@ else:
 
 
 import
-  libp2p/protobuf/minprotobuf,
-  libp2p/varint
-import
-  ../../utils/protobuf,
+  ../../../common/protobuf,
   ./rpc
 
 

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -9,10 +9,9 @@ import
   chronos, 
   stint,
   web3,
-  eth/keys,
-  libp2p/protobuf/minprotobuf
+  eth/keys
 import
-  ../../utils/protobuf
+  ../../../common/protobuf
 
 type RlnRelayResult*[T] = Result[T, string]
 

--- a/waku/v2/protocol/waku_store/rpc_codec.nim
+++ b/waku/v2/protocol/waku_store/rpc_codec.nim
@@ -4,13 +4,11 @@ else:
   {.push raises: [].}
 
 import
-  nimcrypto/hash,
-  libp2p/protobuf/minprotobuf,
-  libp2p/varint
+  nimcrypto/hash
 import
-  ../waku_message,
-  ../../utils/protobuf,
+  ../../../common/protobuf,
   ../../utils/time,
+  ../waku_message,
   ./common,
   ./rpc
 

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -45,7 +45,7 @@ import
   libp2p/stream/connection,
   ../../node/peer_manager/peer_manager,
   ./waku_swap_types,
-  ../../utils/protobuf,
+  ../../../common/protobuf,
   ../../waku/v2/protocol/waku_swap/waku_swap_contracts
 
 export waku_swap_types


### PR DESCRIPTION
Following previous work with `sqlite.nim` and `envvar_serialziation.nim` modules, this PR moves the protobuf module to the `common` module. This module should, in the future, act as a "facade" for the protobuf codec APIs.

- [x] Move `protobuf.nim` under `common` module
- [x] Re-export libp2p's protobuf codec APIs
- [x] Update imports accordingly 