### PR TITLE
fix(lightpush): waku lightpush rpc codec support optional fields

### DIFF
--- a/waku/v2/protocol/waku_lightpush/rpc.nim
+++ b/waku/v2/protocol/waku_lightpush/rpc.nim
@@ -4,6 +4,8 @@ else:
   {.push raises: [].}
 
 import
+  std/options
+import
   ../waku_message
 
 type
@@ -13,9 +15,9 @@ type
 
   PushResponse* = object
     isSuccess*: bool
-    info*: string
+    info*: Option[string]
 
   PushRPC* = object
     requestId*: string
-    request*: PushRequest
-    response*: PushResponse
+    request*: Option[PushRequest]
+    response*: Option[PushResponse]


### PR DESCRIPTION
> ~~Waiting for https://github.com/vacp2p/waku/pull/8~~

To follow the [Waku lightpush `2.0.0-beta1` protobuf definition](https://github.com/vacp2p/waku/blob/main/waku/lightpush/v2beta1/lightpush.proto):

- [x] Update RPC types to match the protobuf definition. Use explicit `Option[T]` types when the field is optional.
- [x] Update API-RPC type mappings accordingly
- [x] Update the protocol accordingly

This is a dependency of the _Make `waku_message.nim` comply with the protobuf definition_ task.