### PR TITLE
fix(filter): waku filter rpc codec support optional fields

### DIFF
--- a/waku/common/protobuf.nim
+++ b/waku/common/protobuf.nim
@@ -19,6 +19,8 @@ proc write3*(proto: var ProtoBuffer, field: int, value: auto) =
   when value is Option:
     if value.isSome():
       proto.write(field, value.get())
+  elif value is bool:
+    proto.write(field, zint(value))
   else:
     proto.write(field, value)
 

--- a/waku/v2/protocol/waku_filter/client.nim
+++ b/waku/v2/protocol/waku_filter/client.nim
@@ -98,7 +98,7 @@ proc initProtocolHandler(wf: WakuFilterClient) =
     let rpc = decodeReqRes.get()
     trace "filter message received"
 
-    if rpc.push == MessagePush():
+    if rpc.push.isNone():
       waku_filter_errors.inc(labelValues = [emptyMessagePushFailure])
       # TODO: Manage the empty push message error. Perform any action?
       return
@@ -108,7 +108,7 @@ proc initProtocolHandler(wf: WakuFilterClient) =
     let
       peerId = conn.peerId
       requestId = rpc.requestId 
-      push = rpc.push
+      push = rpc.push.get()
 
     info "received filter message push", peerId=conn.peerId, requestId=requestId
     wf.handleMessagePush(peerId, requestId, push)
@@ -149,11 +149,11 @@ proc sendFilterRequestRpc(wf: WakuFilterClient,
 
   let rpc = FilterRpc(
     requestId: requestId,
-    request: FilterRequest(
+    request: some(FilterRequest(
       subscribe: subscribe, 
       pubSubTopic: pubsubTopic, 
       contentFilters: contentFilters
-    )
+    ))
   )
 
   let sendRes = await wf.sendFilterRpc(rpc, peer)

--- a/waku/v2/protocol/waku_filter/protocol.nim
+++ b/waku/v2/protocol/waku_filter/protocol.nim
@@ -72,9 +72,9 @@ type
 proc handleFilterRequest(wf: WakuFilter, peerId: PeerId, rpc: FilterRPC) =
   let 
     requestId = rpc.requestId
-    subscribe = rpc.request.subscribe
-    pubsubTopic =  rpc.request.pubsubTopic
-    contentTopics = rpc.request.contentFilters.mapIt(it.contentTopic)
+    subscribe = rpc.request.get().subscribe
+    pubsubTopic =  rpc.request.get().pubsubTopic
+    contentTopics = rpc.request.get().contentFilters.mapIt(it.contentTopic)
 
   if subscribe:
     info "added filter subscritpiton", peerId=peerId, pubsubTopic=pubsubTopic, contentTopics=contentTopics
@@ -101,7 +101,7 @@ proc initProtocolHandler(wf: WakuFilter) =
 
     ## Filter request
     # Subscription/unsubscription request
-    if rpc.request == FilterRequest():
+    if rpc.request.isNone():
       waku_filter_errors.inc(labelValues = [emptyFilterRequestFailure])
       # TODO: Manage the empty filter request message error. Perform any action?
       return
@@ -185,7 +185,7 @@ proc handleMessage*(wf: WakuFilter, pubsubTopic: PubsubTopic, msg: WakuMessage) 
 
     let rpc = FilterRPC(
       requestId: sub.requestId,
-      push: MessagePush(messages: @[msg])
+      push: some(MessagePush(messages: @[msg]))
     )
 
     let res = await wf.sendFilterRpc(rpc, sub.peer)

--- a/waku/v2/protocol/waku_filter/rpc.nim
+++ b/waku/v2/protocol/waku_filter/rpc.nim
@@ -1,12 +1,21 @@
-import ../waku_message
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/options
+import 
+  ../waku_message
+
 
 type
   ContentFilter* = object
-    contentTopic*: ContentTopic
+    contentTopic*: string
 
   FilterRequest* = object
     contentFilters*: seq[ContentFilter]
-    pubSubTopic*: string
+    pubsubTopic*: string
     subscribe*: bool
 
   MessagePush* = object
@@ -14,5 +23,5 @@ type
 
   FilterRPC* = object
     requestId*: string
-    request*: FilterRequest
-    push*: MessagePush
+    request*: Option[FilterRequest]
+    push*: Option[MessagePush]


### PR DESCRIPTION
> ~~Waiting for https://github.com/vacp2p/waku/pull/9~~

To follow the [Waku filter `2.0.0-beta1` protobuf definition](https://github.com/vacp2p/waku/blob/main/waku/filter/v2beta1/filter.proto):

- [x] Update RPC types to match the protobuf definition. Use explicit `Option[T]` types when the field is optional.
- [x] Update the protocol accordingly

This is a dependency of the _Make `waku_message.nim` comply with the protobuf definition_ task.