### PR TITLE
refactor(rln): decouple rln types from waku message type

### DIFF
--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -854,14 +854,22 @@ suite "Waku rln relay":
     for index, x in shareX3.mpairs: shareX3[index] = 3
     let shareY3 = shareX3
 
-    ## TODO: when zerokit rln is integrated, RateLimitProof should be initialized passing a rlnIdentifier too (now implicitely set to 0)
+    proc encodeAndGetBuf(proof: RateLimitProof): seq[byte] =
+      return proof.encode().buffer
+
     let
       wm1 = WakuMessage(proof: RateLimitProof(epoch: epoch,
-          nullifier: nullifier1, shareX: shareX1, shareY: shareY1))
+                                              nullifier: nullifier1, 
+                                              shareX: shareX1, 
+                                              shareY: shareY1).encodeAndGetBuf())
       wm2 = WakuMessage(proof: RateLimitProof(epoch: epoch,
-          nullifier: nullifier2, shareX: shareX2, shareY: shareY2))
+                                              nullifier: nullifier2, 
+                                              shareX: shareX2, 
+                                              shareY: shareY2).encodeAndGetBuf())
       wm3 = WakuMessage(proof: RateLimitProof(epoch: epoch,
-          nullifier: nullifier3, shareX: shareX3, shareY: shareY3))
+                                              nullifier: nullifier3, 
+                                              shareX: shareX3, 
+                                              shareY: shareY3).encodeAndGetBuf())
 
     # check whether hasDuplicate correctly finds records with the same nullifiers but different secret shares
     # no duplicate for wm1 should be found, since the log is empty

--- a/tests/v2/test_wakunode_rln_relay.nim
+++ b/tests/v2/test_wakunode_rln_relay.nim
@@ -235,8 +235,9 @@ procSuite "WakuNode - RLN relay":
                                                               memKeys = node1.wakuRlnRelay.membershipKeyPair,
                                                               memIndex = MembershipIndex(1),
                                                               epoch = epoch)
-    doAssert(rateLimitProofRes.isOk())
-    let rateLimitProof = rateLimitProofRes.value
+    require:
+      rateLimitProofRes.isOk()
+    let rateLimitProof = rateLimitProofRes.get().encode().buffer
 
     let message = WakuMessage(payload: @payload,
                               contentTopic: contentTopic,


### PR DESCRIPTION
From this comment https://github.com/status-im/nwaku/pull/1386#discussion_r1025370353 related to the cyclic import issues in RLN:

> We need to break that cycle. And it should be done this way:
> 
> 1. Waku message's `proof` field should be changed to `seq[byte]` type. With that, we break the `waku_rln_relay -> waku_message` dependency.
> 2. Consequently, we'll have to decode that buffer within the `waku_rln_relay` module. The buffer should be decoded whenever you need to access the `proof` field.
> 
> Given the current RLN code layout, this last part will be cumbersome. But this is what we need.