### PR TITLE
chore: add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+[{Makefile, *.sh}]
+indent_style = tab
+
+# Trailing spaces in markdown indicate word wrap
+[{*.markdown,*.md}]
+trim_trailing_spaces = false
+max_line_length = 80


### PR DESCRIPTION
This PR addresses a long-existing concern: trailing whitespaces.

- [x] Add `.editorconfig` file for editor configuration homogeneity. Configure to remove the trailing whitespaces automatically. 

Every time a file is modified, the trailing whitespaces will be removed. This will allow us to follow an incremental approach toward a cleaner codebase.