### PR TITLE
chore(store): remove waku swap integration from store protocol

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+[{Makefile, *.sh}]
+indent_style = tab
+
+# Trailing spaces in markdown indicate word wrap
+[{*.markdown,*.md}]
+trim_trailing_spaces = false
+max_line_length = 80

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -2,10 +2,10 @@
 
 import
   std/tables,
-  stew/shims/net as stewNet, 
+  stew/shims/net as stewNet,
   testutils/unittests,
-  chronos, 
-  chronicles, 
+  chronos,
+  chronicles,
   libp2p/switch,
   libp2p/protobuf/minprotobuf,
   libp2p/stream/bufferstream,
@@ -15,11 +15,9 @@ import
   eth/keys
 import
   ../../waku/v2/node/waku_node,
-  ../../waku/v2/node/message_store/queue_store,
-  ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_swap/waku_swap,
   ../../waku/v2/utils/peers,
-  ../test_helpers, 
+  ../test_helpers,
   ./utils,
   ./testlib/common
 
@@ -50,106 +48,3 @@ procSuite "Waku SWAP Accounting":
     check:
       decodedCheque.isErr == false
       decodedCheque.get() == cheque
-
-  # TODO: To do this reliably we need access to contract node
-  # With current logic state isn't updated because of bad cheque
-  # Consider moving this test to e2e test, and/or move swap module to be on by default
-  asyncTest "Update accounting state after store operations":
-    ## Setup
-    let
-      serverKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60102))
-      clientKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60100))
-
-    await allFutures(client.start(), server.start())
-
-    await server.mountSwap()
-    await server.mountStore(store=StoreQueueRef.new())
-    await client.mountSwap()
-    await client.mountStore()
-    client.mountStoreClient()
-
-    client.wakuSwap.setPeer(server.peerInfo.toRemotePeerInfo())
-    server.wakuSwap.setPeer(client.peerInfo.toRemotePeerInfo())
-    
-    client.setStorePeer(server.peerInfo.toRemotePeerInfo())
-    server.setStorePeer(client.peerInfo.toRemotePeerInfo())
-
-    ## Given
-    let message = fakeWakuMessage()
-    require server.wakuStore.store.put(DefaultPubsubTopic, message).isOk()
-
-    let serverPeer = server.peerInfo.toRemotePeerInfo()
-    let req = HistoryQuery(contentTopics: @[DefaultContentTopic])
-
-    ## When
-    let queryRes = await client.query(req, peer=serverPeer)
-
-    ## Then
-    check queryRes.isOk()
-
-    let response = queryRes.get()
-    check:
-      response.messages == @[message]
-
-    check:
-      client.wakuSwap.accounting[server.peerInfo.peerId] == 1
-      server.wakuSwap.accounting[client.peerInfo.peerId] == -1
-    
-    ## Cleanup
-    await allFutures(client.stop(), server.stop())
-
-
-  # This test will only Be checked if in Mock mode
-  # TODO: Add cheque here
-  asyncTest "Update accounting state after sending cheque":
-    ## Setup
-    let
-      serverKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60202))
-      clientKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60200))
-    
-    # Define the waku swap Config for this test
-    let swapConfig = SwapConfig(mode: SwapMode.Mock, paymentThreshold: 1, disconnectThreshold: -1)
-
-    # Start nodes and mount protocols
-    await allFutures(client.start(), server.start())
-    await server.mountSwap(swapConfig)
-    await server.mountStore(store=StoreQueueRef.new())
-    await client.mountSwap(swapConfig)
-    await client.mountStore()
-    client.mountStoreClient()
-
-    client.wakuSwap.setPeer(server.peerInfo.toRemotePeerInfo())
-    server.wakuSwap.setPeer(client.peerInfo.toRemotePeerInfo())
-
-    client.setStorePeer(server.peerInfo.toRemotePeerInfo())
-    server.setStorePeer(client.peerInfo.toRemotePeerInfo())
-    
-    ## Given
-    let message = fakeWakuMessage()
-    require server.wakuStore.store.put(DefaultPubsubTopic, message).isOk()
-    
-    let serverPeer = server.peerInfo.toRemotePeerInfo()
-    let req = HistoryQuery(contentTopics: @[DefaultContentTopic])
-
-    ## When
-    # TODO: Handshakes - for now we assume implicit, e2e still works for PoC
-    let res1 = await client.query(req, peer=serverPeer)
-    let res2 = await client.query(req, peer=serverPeer)
-
-    require:
-      res1.isOk()
-      res2.isOk()
-
-    ## Then
-    check:
-      # Accounting table updated with credit and debit, respectively
-      # After sending a cheque the balance is partially adjusted
-      client.wakuSwap.accounting[server.peerInfo.peerId] == 1
-      server.wakuSwap.accounting[client.peerInfo.peerId] == -1
-
-    ## Cleanup
-    await allFutures(client.stop(), server.stop())


### PR DESCRIPTION
Removing support for the Waku swap protocol has been discussed for some time. As nobody has raised any concerns, I remove the part that integrates with the Waku store protocol.

- [x] Remove the Waku swap integration from the current Waku store protocol handler and client implementations.
- [x] Remove the corresponding test cases.

ℹ️ This PR depends on #1403 